### PR TITLE
fix: fix output levels

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -126,7 +126,7 @@ export class BomBuilder {
     logger.info(LogPrefixes.INFO, `linking Component.dependencies...`)
     this.linkDependencies(metafile, components)
 
-    logger.log(LogPrefixes.LOG, 'done building Components from modules...')
+    logger.info(LogPrefixes.INFO, 'done building Components from modules...')
     return pkgs
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -224,10 +224,13 @@ export const cyclonedxEsbuildPlugin = (opts: CycloneDxEsbuildPluginOptions = {})
   }
 })
 
+/**
+ * from {@link esbuild.LogLevel} to {@link makeConsoleLogger}
+ */
 const LogLevelMap: Record<esbuild.LogLevel, number> = {
-  'silent': -1,
-  'error': 0,
-  'warning': 0,
+  'silent': 0,
+  'error': 1,
+  'warning': 1,
   'info': 2,
   'debug': 3,
   'verbose': 4,


### PR DESCRIPTION
per default, log and higher are emitted.
Only silent dismisses all logs.
