### PR TITLE
refactor: inter-compat

### DIFF
--- a/src/_helpers.ts
+++ b/src/_helpers.ts
@@ -18,7 +18,6 @@ Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
 import {spawnSync} from "node:child_process";
-import type {BinaryLike} from "node:crypto";
 import {createHash} from "node:crypto";
 import {existsSync, readFileSync, writeSync} from "node:fs"
 import {dirname, isAbsolute, join, relative, resolve, sep} from "node:path"
@@ -205,7 +204,7 @@ export function isValidPackageJSON(pkg: any): pkg is ValidPackageJSON {
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }
 
-function sha256hex(data: string | BinaryLike): string  {
+function sha256hex(data: string): string  {
   return createHash('sha256').update(data).digest('hex')
 }
 

--- a/src/_helpers.ts
+++ b/src/_helpers.ts
@@ -205,11 +205,11 @@ export function isValidPackageJSON(pkg: any): pkg is ValidPackageJSON {
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }
 
-function sha256hex(data: BinaryLike): string  {
+function sha256hex(data: string | BinaryLike): string  {
   return createHash('sha256').update(data).digest('hex')
 }
 
-const spawRequiresShell = process.platform === "win32"
+const spawnRequiresShell = process.platform.startsWith('win')
 
 // region relative paths
 
@@ -226,7 +226,7 @@ function getYarnCacheFolder(cwd: string): string | null {
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8',
       cwd,
-      shell: spawRequiresShell,
+      shell: spawnRequiresShell,
     })
     if (sr2.status === 0) {
       cf = sr2.stdout.trim()
@@ -236,7 +236,7 @@ function getYarnCacheFolder(cwd: string): string | null {
           stdio: ['ignore', 'pipe', 'ignore'],
           encoding: 'utf-8',
           cwd,
-          shell: spawRequiresShell,
+          shell: spawnRequiresShell,
         })
       if (sr1.status === 0) {
         cf = sr1.stdout.trim()
@@ -259,7 +259,7 @@ function getBunCacheFolder(cwd: string): string | null {
         stdio: ['ignore', 'pipe', 'ignore'],
         encoding: 'utf-8',
         cwd,
-        shell: spawRequiresShell,
+        shell: spawnRequiresShell,
       })
     if (sr.status === 0) {
       cf = sr.stdout.trim()


### PR DESCRIPTION
fixes some intercompatibility things related to latest typing.

see https://github.com/CycloneDX/cyclonedx-esbuild/actions/runs/27921767956/job/82616622159
```text

Error: src/_helpers.ts(209,38): error TS2345: Argument of type 'BinaryLike' is not assignable to parameter of type 'string | ArrayBufferView<ArrayBufferLike>'.
  Type 'ArrayBuffer' is not assignable to type 'string | ArrayBufferView<ArrayBufferLike>'.
    Type 'ArrayBuffer' is missing the following properties from type 'DataView<ArrayBufferLike>': buffer, byteOffset, getFloat32, getFloat64, and 20 more.

```
