### PR TITLE
fix: Log|Info|Debug output are properly formatted

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * Fixed
-  * Debug output details are more verbose (via [#165])
+  * Log|Info|Debug output are properly formatted (via [#165])
 * Tests
   * Added testbeds for integration (via [#164])
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,10 +6,13 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* Fixed
+  * Debug output details are more verbose (via [#165])
 * Tests
   * Added testbeds for integration (via [#164])
 
 [#164]: https://github.com/CycloneDX/cyclonedx-esbuild/pull/164
+[#165]: https://github.com/CycloneDX/cyclonedx-esbuild/pull/165
 
 ## 1.4.0 - 2026-06-29
 

--- a/src/_helpers.ts
+++ b/src/_helpers.ts
@@ -121,7 +121,7 @@ export function * makeToolCs(
   /* eslint-enable no-labels */
 
   for (const [packageJsonPath, cType] of packageJsonPaths) {
-    logger.info(LogPrefixes.INFO, 'try to build new Tool from PkgPath', packageJsonPath)
+    logger.info(LogPrefixes.INFO, 'try building new Tool from PkgPath', packageJsonPath)
     /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expected */
     const packageJson: PackageDescription['packageJson'] = loadJsonFile(packageJsonPath) ?? {}
     normalizePackageManifest(

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -71,7 +71,8 @@ export class BomBuilder {
     outputReproducible: boolean,
     logger: Console
   ): Bom {
-    logger.debug(LogPrefixes.DEBUG, 'metafile:', metafile)
+    logger.debug('%s metafile: %j', LogPrefixes.DEBUG, metafile)
+
     const bom = new Bom()
 
     logger.info(LogPrefixes.INFO, 'generating components...')
@@ -180,7 +181,7 @@ export class BomBuilder {
       } else {
         component = packageComponents.get(pkg.path)
         if (component === undefined) {
-          logger.info(LogPrefixes.INFO, 'try to build new Component from PkgPath:', pkg.path)
+          logger.info(LogPrefixes.INFO, 'try building new Component from PkgPath:', pkg.path)
           try {
             component = this.makeComponent(pkg, collectEvidence, logger)
           } catch (err) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -261,7 +261,7 @@ export async function run(process_: NodeJS.Process): Promise<number> {
   }
   logger.log(LogPrefixes.LOG, 'writing BOM to:', options.outputFile)
   const written = await writeAllSync(outputFD, serialized)
-  logger.info(LogPrefixes.INFO, 'wrote', written, 'bytes to:', options.outputFile)
+  logger.info('%s wrote %d bytes to %s', LogPrefixes.INFO, written, options.outputFile)
 
   return written > 0
     ? ExitCode.SUCCESS

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,8 +166,8 @@ export async function run(process_: NodeJS.Process): Promise<number> {
   const options: CommandOptions = program.opts()
   // all output shall be bound to stdError - stdOut is for result output only
   const logger = makeConsoleLogger(process_.stderr, process_.stderr, options.verbose)
-  logger.debug(`${LogPrefixes.DEBUG} options: %j`, options)
-  logger.debug(`${LogPrefixes.DEBUG} args: %j`, program.args)
+  logger.debug('%s options: %j', LogPrefixes.DEBUG, options)
+  logger.debug('%s args: %j', LogPrefixes.DEBUG, program.args)
 
   const serializeSpec = SpecVersionDict[options.specVersion]
   if (serializeSpec === undefined) {
@@ -259,9 +259,9 @@ export async function run(process_: NodeJS.Process): Promise<number> {
     }
     outputFD = openSync(outputFPn, 'w')
   }
-  logger.log(`${LogPrefixes.LOG} writing BOM to: %s`, options.outputFile)
+  logger.log(LogPrefixes.LOG, 'writing BOM to:', options.outputFile)
   const written = await writeAllSync(outputFD, serialized)
-  logger.info(`${LogPrefixes.INFO} wrote %d bytes to: %s`, written, options.outputFile)
+  logger.info(LogPrefixes.INFO, 'wrote', written, 'bytes to:', options.outputFile)
 
   return written > 0
     ? ExitCode.SUCCESS

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -259,7 +259,7 @@ export const cyclonedxEsbuildPlugin = (opts: CycloneDxEsbuildPluginOptions = {})
       }
       logger.log(LogPrefixes.LOG, 'writing BOM to', options.outputFile)
       const written = await writeAllSync(openSync(outputFPn, 'w'), serialized);
-      logger.info(LogPrefixes.INFO, 'wrote', written, 'bytes to', options.outputFile)
+      logger.info('%s wrote %d bytes to %s', LogPrefixes.INFO, written, options.outputFile)
     });
   }
 })

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -138,7 +138,7 @@ export const cyclonedxEsbuildPlugin = (opts: CycloneDxEsbuildPluginOptions = {})
       ] ?? LogLevelMap.warning
     )
 
-    logger.debug(`${LogPrefixes.DEBUG} setup => opt: %j`, opts)
+    logger.debug('%s setup => opt: %j', LogPrefixes.DEBUG, opts)
     const options = {
       gatherLicenseTexts: opts.gatherLicenseTexts ?? false,
       outputReproducible: opts.outputReproducible ?? false,
@@ -148,7 +148,7 @@ export const cyclonedxEsbuildPlugin = (opts: CycloneDxEsbuildPluginOptions = {})
       validate: opts.validate,
       mcType: opts.mcType ?? ComponentType.Application
     } as const satisfies CycloneDxEsbuildPluginOptions
-    logger.debug(`${LogPrefixes.DEBUG} setup => options: %j`, options)
+    logger.debug('%s setup => options: %j', LogPrefixes.DEBUG, options)
 
     const serializeSpec = SpecVersionDict[options.specVersion]
     if (serializeSpec === undefined) {
@@ -164,7 +164,7 @@ export const cyclonedxEsbuildPlugin = (opts: CycloneDxEsbuildPluginOptions = {})
         /* c8 ignore next */
         throw new Error('missing result.metafile')
       }
-      logger.info(LogPrefixes.INFO, 'start build BOM ...')
+      logger.info(LogPrefixes.INFO, 'start building BOM...')
 
       const cdxExternalReferenceFactory = new FromNodePackageJsonFactories.ExternalReferenceFactory()
       const cdxLicenseFactory = new LicenseFactories.LicenseFactory(spdxExpressionParse)
@@ -259,7 +259,7 @@ export const cyclonedxEsbuildPlugin = (opts: CycloneDxEsbuildPluginOptions = {})
       }
       logger.log(LogPrefixes.LOG, 'writing BOM to', options.outputFile)
       const written = await writeAllSync(openSync(outputFPn, 'w'), serialized);
-      logger.info(LogPrefixes.INFO, 'wrote %d bytes to %s', written, options.outputFile)
+      logger.info(LogPrefixes.INFO, 'wrote', written, 'bytes to', options.outputFile)
     });
   }
 })


### PR DESCRIPTION


### Description

fixed log|info|debug output details.
- debug: `metafile` is no longer truncated
- info: is properly formatted and phrased
- misc refactoring/rewording

Resolves or fixes issue: <!-- ✍️ Add GitHub issue number in format `#0000` - if there is none fitting, create one -->

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX//cyclonedx-esbuild/blob/main/CONTRIBUTING.md) guidelines
