### PR TITLE
fix: don't treat subpath directory manifests as valid packages

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
-<!-- add unreleased items here -->
+* Fixed
+  * No longer emit a spurious component for legacy subpath resolution directories
+    (e.g. `@hookform/resolvers/zod`) that ship their own `package.json` with a
+    non-installable name. Such modules are now attributed to their real owning package.
 
 ## 1.4.2 - 2026-07-02
 

--- a/src/_helpers.ts
+++ b/src/_helpers.ts
@@ -191,12 +191,31 @@ function isSubDirectoryOfNodeModulesFolder(path: string): boolean {
 }
 
 
+/**
+ * Whether `name` is a valid npm package name.
+ *
+ * The only rule relevant here is the segment count: an unscoped name has no `/`, a scoped
+ * name is exactly `@scope/name` (one `/`). Anything else ΓÇö e.g. `@hookform/resolvers/zod`
+ * or `demo-lib/sub` ΓÇö is not an installable package but a legacy *subpath directory* that
+ * ships its own `package.json` for bundler resolution. Treating such a manifest as a package
+ * yields a spurious, non-existent component, so it must be rejected here.
+ *
+ * This intentionally does not enforce case or the full npm charset, to avoid rejecting real
+ * (possibly legacy) packages; only the invalid path-segment shape is filtered out.
+ */
+export function isValidNpmPackageName(name: string): boolean {
+  return name.startsWith('@')
+    ? /^@[^/\\]+\/[^/\\]+$/.test(name)
+    : !name.includes('/') && !name.includes('\\')
+}
+
 export function isValidPackageJSON(pkg: any): pkg is ValidPackageJSON {
   // checking for the existence of name and version properties
   // both are required for a valid package.json according to https://docs.npmjs.com/cli/v10/configuring-npm/package-json
   return isNonNullable(pkg)
     /* eslint-disable @typescript-eslint/no-unsafe-member-access -- false-positive */
     && isString(pkg.name)
+    && isValidNpmPackageName(pkg.name)
     && isString(pkg.version)
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }

--- a/tests/unit/helpers.test.js
+++ b/tests/unit/helpers.test.js
@@ -1,0 +1,76 @@
+/*!
+This file is part of CycloneDX generator for esbuild.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OWASP Foundation. All Rights Reserved.
+*/
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { afterAll, beforeAll, describe, expect, it } = require('@jest/globals')
+
+const { isValidNpmPackageName, getPackageConfig } = require('../../dist/_helpers.js')
+
+describe('isValidNpmPackageName', () => {
+  it.each([
+    ['unscoped', 'demo-lib', true],
+    ['scoped', '@hookform/resolvers', true],
+    ['scoped with dots/dashes', '@scope/some.pkg-name', true],
+    // legacy subpath resolution stubs — NOT installable packages:
+    ['unscoped subpath dir', 'demo-lib/sub', false],
+    ['scoped subpath dir', '@hookform/resolvers/zod', false],
+    ['scope only', '@scope', false],
+    ['windows separator', 'demo-lib\\sub', false],
+  ])('%s -> %s is %s', (_desc, name, expected) => {
+    expect(isValidNpmPackageName(name)).toBe(expected)
+  })
+})
+
+describe('getPackageConfig', () => {
+  let root
+
+  beforeAll(() => {
+    // Mirror node_modules/@hookform/resolvers/{package.json, zod/package.json}:
+    // a real package plus a legacy subpath directory shipping its own manifest with a
+    // non-installable name.
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'cdx-subpath-'))
+    const pkgDir = path.join(root, 'node_modules', 'demo-lib')
+    const subDist = path.join(pkgDir, 'sub', 'dist')
+    fs.mkdirSync(subDist, { recursive: true })
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'demo-lib', version: '1.0.0' })
+    )
+    fs.writeFileSync(
+      path.join(pkgDir, 'sub', 'package.json'),
+      JSON.stringify({ name: 'demo-lib/sub', version: '9.9.9', private: true })
+    )
+    fs.writeFileSync(path.join(subDist, 'sub.js'), 'module.exports = {}\n')
+  })
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('attributes a subpath module to the real package, not the subpath stub', () => {
+    const subFile = path.join(root, 'node_modules', 'demo-lib', 'sub', 'dist', 'sub.js')
+    const pkg = getPackageConfig(subFile)
+    expect(pkg).toBeDefined()
+    expect(pkg.packageJson.name).toBe('demo-lib')
+    expect(pkg.packageJson.version).toBe('1.0.0')
+  })
+})


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-days or even
∞ ban from interacting with the project depending on reoccurrence and severity.

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

Bundling an app that imports a package subpath such as `@hookform/resolvers/zod` produces an extra, non-existent component in the SBOM:

```
pkg:npm/%40hookform%2Fresolvers@5.2.2       ← real package
pkg:npm/%40hookform%2Fresolvers%2Fzod@1.0.0 ← spurious
```

The second entry is not an installable npm package and does not correspond to anything in the dependency tree. 

#### Cause

Some packages ship a nested `package.json` inside a subpath directory so bundlers can resolve `pkg/subpath` without relying on an `exports` map, for example:

```
node_modules/@hookform/resolvers/package.json
  { "name": "@hookform/resolvers", "version": "5.2.2" }

node_modules/@hookform/resolvers/zod/package.json
  { "name": "@hookform/resolvers/zod", "version": "1.0.0", "private": true, "main": "dist/zod.js" }
```

`@hookform/resolvers/zod` is only an import subpath, not a real package. Its manifest carries a non-installable name (two slashes) and a placeholder version.

When `getPackageConfig` walks up from a bundled subpath file (e.g. `.../@hookform/resolvers/zod/dist/zod.mjs`), the first `package.json` it reaches is this stub. It accepts it because `isValidPackageJSON` only checked that `name` and `version` are strings, not that `name` is a valid npm package name. As a result the stub becomes its own component, and the module is never attributed to the real owning package `@hookform/resolvers`.

#### Fix

`isValidPackageJSON` now additionally requires `name` to be a valid npm package name, via a new `isValidNpmPackageName` helper:

- unscoped names contain no `/`
- scoped names are exactly `@scope/name` (a single `/`)

This matches the structural rule enforced by `validate-npm-package-name` (whose scoped regex `^(?:@([^/]+?)[/])?([^/]+?)$` permits at most one slash). The check is intentionally limited to the path-segment shape. It does not enforce case or the full npm charset, so it cannot reject a real, possibly legacy, package; it only rejects names whose slash count makes them non-installable.

With the stub rejected, `getPackageConfig` keeps walking up the tree and correctly resolves the module to `@hookform/resolvers@5.2.2`. The spurious component disappears and its module folds into the real package.

#### Verification

Empirically checked against 359 distinct real package names from a production app's SBOM: exactly one name is rejected `@hookform/resolvers/zod` and zero real packages are affected.

Also run [`rollup-plugin-sbom`](https://github.com/janbiasi/rollup-plugin-sbom/) against the same app, and observed that it does not emit the spurious extra component.

#### Tests

`tests/unit/helpers.test.js` adds:

- `isValidNpmPackageName` cases: unscoped, scoped, scoped-with-dots/dashes, unscoped subpath stub, scoped subpath stub, scope-only, Windows separator.
- `getPackageConfig`: a module under a subpath directory whose stub `package.json` has a non-installable name resolves to the real parent package, not the stub.

#### Reproducer

A standalone reproducer accompanies this fix: https://github.com/Churro/cyclonedx-esbuild/tree/repro/hookform-subpath-sbom-repro

It bundles a fake `demo-lib` that mirrors the `@hookform/resolvers` layout (`demo-lib` + a `demo-lib/sub` subpath stub) and asserts, via `verify.mjs`, that no spurious `demo-lib/sub@9.9.9` component is emitted:

- before the fix: SBOM contains `demo-lib@1.0.0` and `demo-lib/sub@9.9.9` (exit 1)
- after the fix: SBOM contains only `demo-lib@1.0.0` (exit 0)


### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`: Claude
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`: Sonnet 5
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`: Generate a standalone reproducer + tests

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX//cyclonedx-esbuild/blob/main/CONTRIBUTING.md) guidelines
