### PR TITLE
tests: npm12 compat

### DIFF
--- a/tests/_testbeds/angular20-npm/package.json
+++ b/tests/_testbeds/angular20-npm/package.json
@@ -34,7 +34,6 @@
     "build:sbom": "node ../../../bin/cyclonedx-esbuild-cli.js -vvv --gather-license-texts --output-reproducible -o dist/first-app/bom.json --validate dist/first-app/stats.json",
     "build": "npm run build:ng && npm run build:sbom"
   },
-  "packageManager": "npm",
   "devEngines": {
     "packageManager": {
       "name": "npm",

--- a/tests/_testbeds/esbuild-latest/package.json
+++ b/tests/_testbeds/esbuild-latest/package.json
@@ -20,5 +20,10 @@
   "overrides": {
     "@cyclonedx/cyclonedx-eslint-testing-custom-package": "file:../../_data/custom-package/package.tgz"
   },
-  "packageManager": "npm"
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "error"
+    }
+  }
 }

--- a/tests/_testbeds/esbuild-lowest/package-lock.json
+++ b/tests/_testbeds/esbuild-lowest/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../..": {
       "name": "@cyclonedx/cyclonedx-esbuild",
-      "version": "1.3.1",
+      "version": "1.4.2",
       "dev": true,
       "funding": [
         {
@@ -41,10 +41,10 @@
         "@types/normalize-package-data": "^2.4.4",
         "@types/spdx-expression-parse": "^3.0.5",
         "c8": "^11",
-        "esbuild": "^0.27.0",
-        "jest": "30.3.0",
-        "jest-junit": "16.0.0",
-        "npm-run-all2": "^8.0.1",
+        "esbuild": "^0.28.1",
+        "jest": "30.4.2",
+        "jest-junit": "17.0.0",
+        "npm-run-all2": "^8.0.1||^9.0.2",
         "typescript": "^5.9.3"
       },
       "engines": {

--- a/tests/_testbeds/esbuild-lowest/package.json
+++ b/tests/_testbeds/esbuild-lowest/package.json
@@ -20,5 +20,13 @@
   "overrides": {
     "@cyclonedx/cyclonedx-eslint-testing-custom-package": "file:../../_data/custom-package/package.tgz"
   },
-  "packageManager": "npm"
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "error"
+    }
+  },
+  "allowScripts": {
+    "esbuild": true
+  }
 }

--- a/tests/_testbeds/juice-shop-frontend/package-lock.json
+++ b/tests/_testbeds/juice-shop-frontend/package-lock.json
@@ -87,7 +87,7 @@
     },
     "../../..": {
       "name": "@cyclonedx/cyclonedx-esbuild",
-      "version": "1.3.1",
+      "version": "1.4.2",
       "funding": [
         {
           "type": "individual",
@@ -110,10 +110,10 @@
         "@types/normalize-package-data": "^2.4.4",
         "@types/spdx-expression-parse": "^3.0.5",
         "c8": "^11",
-        "esbuild": "^0.27.0",
-        "jest": "30.3.0",
-        "jest-junit": "16.0.0",
-        "npm-run-all2": "^8.0.1",
+        "esbuild": "^0.28.1",
+        "jest": "30.4.2",
+        "jest-junit": "17.0.0",
+        "npm-run-all2": "^8.0.1||^9.0.2",
         "typescript": "^5.9.3"
       },
       "engines": {

--- a/tests/_testbeds/juice-shop-frontend/package.json
+++ b/tests/_testbeds/juice-shop-frontend/package.json
@@ -83,5 +83,10 @@
     "ts-node": "^10.9.2",
     "typescript-eslint": "^8.42.0"
   },
-  "packageManager": "npm"
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "error"
+    }
+  }
 }

--- a/tests/_testbeds/no-treeshaking/package-lock.json
+++ b/tests/_testbeds/no-treeshaking/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../..": {
       "name": "@cyclonedx/cyclonedx-esbuild",
-      "version": "1.3.1",
+      "version": "1.4.2",
       "dev": true,
       "funding": [
         {
@@ -41,10 +41,10 @@
         "@types/normalize-package-data": "^2.4.4",
         "@types/spdx-expression-parse": "^3.0.5",
         "c8": "^11",
-        "esbuild": "^0.27.0",
-        "jest": "30.3.0",
-        "jest-junit": "16.0.0",
-        "npm-run-all2": "^8.0.1",
+        "esbuild": "^0.28.1",
+        "jest": "30.4.2",
+        "jest-junit": "17.0.0",
+        "npm-run-all2": "^8.0.1||^9.0.2",
         "typescript": "^5.9.3"
       },
       "engines": {

--- a/tests/_testbeds/no-treeshaking/package.json
+++ b/tests/_testbeds/no-treeshaking/package.json
@@ -20,10 +20,9 @@
   "overrides": {
     "@cyclonedx/cyclonedx-eslint-testing-custom-package": "file:../../_data/custom-package/package.tgz"
   },
-  "packageManager": "npm",
   "devEngines": {
-    "runtime": {
-      "name": "node",
+    "packageManager": {
+      "name": "npm",
       "onFail": "error"
     }
   }

--- a/tests/_testbeds/react19-bun/package.json
+++ b/tests/_testbeds/react19-bun/package.json
@@ -20,8 +20,11 @@
     "@types/bun": "latest",
     "@cyclonedx/cyclonedx-esbuild": "link:@cyclonedx/cyclonedx-esbuild"
   },
-  "packageManager": "bun",
   "devEngines": {
+    "runtime": {
+      "name": "bun",
+      "onFail": "error"
+    },
     "packageManager": {
       "name": "bun",
       "onFail": "error"

--- a/tests/_testbeds/typescript-npm/package-lock.json
+++ b/tests/_testbeds/typescript-npm/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../../..": {
       "name": "@cyclonedx/cyclonedx-esbuild",
-      "version": "1.3.1",
+      "version": "1.4.2",
       "dev": true,
       "funding": [
         {
@@ -43,10 +43,10 @@
         "@types/normalize-package-data": "^2.4.4",
         "@types/spdx-expression-parse": "^3.0.5",
         "c8": "^11",
-        "esbuild": "^0.27.0",
-        "jest": "30.3.0",
-        "jest-junit": "16.0.0",
-        "npm-run-all2": "^8.0.1",
+        "esbuild": "^0.28.1",
+        "jest": "30.4.2",
+        "jest-junit": "17.0.0",
+        "npm-run-all2": "^8.0.1||^9.0.2",
         "typescript": "^5.9.3"
       },
       "engines": {

--- a/tests/_testbeds/typescript-npm/package.json
+++ b/tests/_testbeds/typescript-npm/package.json
@@ -23,10 +23,9 @@
   "overrides": {
     "@cyclonedx/cyclonedx-eslint-testing-custom-package": "file:../../_data/custom-package/package.tgz"
   },
-  "packageManager": "npm",
   "devEngines": {
-    "runtime": {
-      "name": "node",
+    "packageManager": {
+      "name": "npm",
       "onFail": "error"
     }
   }

--- a/tests/_testbeds/with-external-entrypoints/package-lock.json
+++ b/tests/_testbeds/with-external-entrypoints/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../../..": {
       "name": "@cyclonedx/cyclonedx-esbuild",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "dev": true,
       "funding": [
         {

--- a/tests/_testbeds/with-external-entrypoints/package.json
+++ b/tests/_testbeds/with-external-entrypoints/package.json
@@ -16,10 +16,9 @@
     "@cyclonedx/cyclonedx-eslint-testing-custom-package": "file:../../_data/custom-package/package.tgz",
     "esbuild": "0.28.1"
   },
-  "packageManager": "npm",
   "devEngines": {
-    "runtime": {
-      "name": "node",
+    "packageManager": {
+      "name": "npm",
       "onFail": "error"
     }
   }

--- a/tests/_testbeds/with-externals/package.json
+++ b/tests/_testbeds/with-externals/package.json
@@ -22,10 +22,9 @@
   "overrides": {
     "@cyclonedx/cyclonedx-eslint-testing-custom-package": "file:../../_data/custom-package/package.tgz"
   },
-  "packageManager": "npm",
   "devEngines": {
-    "runtime": {
-      "name": "node",
+    "packageManager": {
+      "name": "npm",
       "onFail": "error"
     }
   }


### PR DESCRIPTION

### Description

make testbeds npm12 compatible

Resolves or fixes issue: <!-- ✍️ Add GitHub issue number in format `#0000` - if there is none fitting, create one -->

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX//cyclonedx-esbuild/blob/main/CONTRIBUTING.md) guidelines
