### PR TITLE
fix: no PURLS for unreachable packages

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * Fixed
-  * Don't emit purls for non-standard package names without reachability qualifiers ([#])
+  * Don't emit purls for non-standard package names without reachability qualifiers ([#192])
 
-[#]: 
+[#192]: https://github.com/CycloneDX/cyclonedx-esbuild/pull/192
 
 ## 1.4.3 - 2026-08-10
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,11 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * Fixed
+  * Don't emit purls for private package without reachability qualifiers ([#193] via [#192])
   * Don't emit purls for non-standard package names without reachability qualifiers ([#192])
 
 [#192]: https://github.com/CycloneDX/cyclonedx-esbuild/pull/192
+[#193]: https://github.com/CycloneDX/cyclonedx-esbuild/issues/193
 
 ## 1.4.3 - 2026-08-10
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* Fixed
+  * Don't emit purls for non-standard package names without reachability qualifiers ([#])
+
+[#]: 
+
 ## 1.4.3 - 2026-08-10
 
 Maintenance release.

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -96,41 +96,42 @@ export class PackageUrlFactory {
    * - https://docs.npmjs.com/cli/v12/configuring-npm/package-json#name
    * - https://docs.npmjs.com/cli/v12/using-npm/scope#publishing-scoped-packages
    */
-  _checkPackageNpmjs (packageName: string): boolean {
-      if (packageName.length > 214 ) {
-        // The name must be less than or equal to 214 characters. This includes the scope for scoped packages.
+  _checkPackageNpmjs(packageName: string): boolean {
+    if (packageName.length > 214) {
+      // The name must be less than or equal to 214 characters. This includes the scope for scoped packages.
+      return false
+    }
+    if (packageName.startsWith('@')) {
+      // scoped package
+      if (packageName.match(/\//g)?.length !== 1
+        || packageName.startsWith('/')
+        || packageName.endsWith('/')
+      ) {
         return false
       }
-      if (packageName.startsWith('@')) {
-        if ( packageName.match(/\//g)?.length !== 1
-          || packageName.startsWith('/')
-          || packageName.endsWith('/')
-        ) {
-          return false
-        }
-      } else {
-        if (packageName.match(/\//g)?.length !== 0) {
-          return false
-        }
-        if (packageName.startsWith('.')
-          || packageName.startsWith(  '_')
-        ) {
-          // The names of scoped packages can begin with a dot or an underscore. This is not permitted without a scope.
-          return false
-        }
-      }
-
-      // TODO: The name ends up being part of a URL, an argument on the command line, and a folder name. Therefore, the name can't contain any non-URL-safe characters.
-
-
-      /* skipped - this does not apply to old packages.
-      if (packageName.toLowerCase() !== packageName) {
-        // New packages must not have uppercase letters in the name.
+    } else {
+      // non-scoped package
+      if (packageName.match(/\//g)?.length !== 0) {
         return false
       }
-      */
+      if (packageName.startsWith('.')
+        || packageName.startsWith('_')
+      ) {
+        // The names of scoped packages can begin with a dot or an underscore. This is not permitted without a scope.
+        return false
+      }
+    }
 
-      return true
+    // TODO: The name ends up being part of a URL, an argument on the command line, and a folder name. Therefore, the name can't contain any non-URL-safe characters.
+
+    /* skipped - this does not apply to old packages that already existed before this rule.
+    if (packageName.toLowerCase() !== packageName) {
+      // New packages must not have uppercase letters in the name.
+      return false
+    }
+    */
+
+    return true
   }
 
 }

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -61,6 +61,17 @@ export class PackageUrlFactory {
       }
     }
 
+    if ( !Object.hasOwn(qualifiers, PurlQualifierNames.DownloadUrl)
+      && !Object.hasOwn(qualifiers, PurlQualifierNames.VcsUrl)
+      && ( !this._checkPackageNpmjs(packageJson.name)
+        /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- safety */
+        || packageJson.version?.length === 0
+      )
+    ) {
+      // package would not be reachable by PackageURL means
+      return undefined
+    }
+
     try {
       // Do not beautify the parameters here, because that is in the domain of PackageURL and its representation.
       // No need to convert an empty "subpath" string to `undefined` and such.
@@ -75,6 +86,51 @@ export class PackageUrlFactory {
     } catch {
       return undefined
     }
+  }
+
+  /**
+   * check is package for guidelines of https://npmjs.com/
+   *
+   * see the docs:
+   * - https://docs.npmjs.com/package-name-guidelines
+   * - https://docs.npmjs.com/cli/v12/configuring-npm/package-json#name
+   * - https://docs.npmjs.com/cli/v12/using-npm/scope#publishing-scoped-packages
+   */
+  _checkPackageNpmjs (packageName: string): boolean {
+      if (packageName.length > 214 ) {
+        // The name must be less than or equal to 214 characters. This includes the scope for scoped packages.
+        return false
+      }
+      if (packageName.startsWith('@')) {
+        if ( packageName.match(/\//g)?.length !== 1
+          || packageName.startsWith('/')
+          || packageName.endsWith('/')
+        ) {
+          return false
+        }
+      } else {
+        if (packageName.match(/\//g)?.length !== 0) {
+          return false
+        }
+        if (packageName.startsWith('.')
+          || packageName.startsWith(  '_')
+        ) {
+          // The names of scoped packages can begin with a dot or an underscore. This is not permitted without a scope.
+          return false
+        }
+      }
+
+      // TODO: The name ends up being part of a URL, an argument on the command line, and a folder name. Therefore, the name can't contain any non-URL-safe characters.
+
+
+      /* skipped - this does not apply to old packages.
+      if (packageName.toLowerCase() !== packageName) {
+        // New packages must not have uppercase letters in the name.
+        return false
+      }
+      */
+
+      return true
   }
 
 }

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -28,8 +28,6 @@ import {isString} from "./_helpers";
 export class PackageUrlFactory {
 
   makeFromPackageJson(packageJson: normalizePackageData.Package): PackageURL | undefined {
-    // !REMINDER: even private packages may have a PURL
-
     let name: string = packageJson.name
     let namespace: string | undefined = undefined
     if ( name.startsWith('@') ) {
@@ -63,7 +61,8 @@ export class PackageUrlFactory {
 
     if ( !Object.hasOwn(qualifiers, PurlQualifierNames.DownloadUrl)
       && !Object.hasOwn(qualifiers, PurlQualifierNames.VcsUrl)
-      && ( !this._checkPackageNpmjs(packageJson.name)
+      && ( Boolean(packageJson.private)
+        || !this._checkPackageNpmjs(packageJson.name)
         /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- safety */
         || packageJson.version?.length === 0
       )

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -62,7 +62,7 @@ export class PackageUrlFactory {
     if ( !Object.hasOwn(qualifiers, PurlQualifierNames.DownloadUrl)
       && !Object.hasOwn(qualifiers, PurlQualifierNames.VcsUrl)
       && ( Boolean(packageJson.private)
-        || !this._checkPackageNpmjs(packageJson.name)
+        || !this.checkPackageNpmjs(packageJson.name)
         /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- safety */
         || packageJson.version?.length === 0
       )
@@ -95,7 +95,7 @@ export class PackageUrlFactory {
    * - https://docs.npmjs.com/cli/v12/configuring-npm/package-json#name
    * - https://docs.npmjs.com/cli/v12/using-npm/scope#publishing-scoped-packages
    */
-  _checkPackageNpmjs(packageName: string): boolean {
+  private checkPackageNpmjs(packageName: string): boolean {
     if (packageName.length > 214) {
       // The name must be less than or equal to 214 characters. This includes the scope for scoped packages.
       return false

--- a/tests/_testbeds/with-non-standard-name/README.md
+++ b/tests/_testbeds/with-non-standard-name/README.md
@@ -1,3 +1,3 @@
 # showcase running as a plugin with **latest** _esbuild_
 
-this package has a name that is not standard to https://www.npmjs.com/
+this package has a name that is non-standard to https://www.npmjs.com/

--- a/tests/_testbeds/with-non-standard-name/package.json
+++ b/tests/_testbeds/with-non-standard-name/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@cyclonedx/cyclonedx-eslint-testbed-with-non-standard-name/testbed",
   "version": "1.0.0",
-  "description": "Example using a name that is not standard to https://www.npmjs.com/",
+  "description": "Example using a name that is non-standard to https://www.npmjs.com/",
   "type": "module",
   "main": "dist/bundle.js",
   "scripts": {

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -81,7 +81,6 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
       "group": "@cyclonedx",
       "version": "0.0.0",
       "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-angular20-npm@0.0.0",
       "evidence": {}
     }
   },
@@ -250,7 +249,6 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
       "evidence": {
         "licenses": [
           {
@@ -571,7 +569,6 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
       "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "excluded",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
       "evidence": {}
     },
     {
@@ -788,7 +785,6 @@ exports[`integration functional: entryPoints are external generated json file: d
       "version": "1.0.0",
       "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "Example using esbuild with external entryPoints",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-with-external-entrypoints@1.0.0",
       "evidence": {}
     }
   },
@@ -809,7 +805,6 @@ exports[`integration functional: entryPoints are external generated json file: d
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
       "evidence": {
         "licenses": [
           {
@@ -833,7 +828,6 @@ exports[`integration functional: entryPoints are external generated json file: d
       "bom-ref": "afdd713844bfa0f7a517f5c864728f1d9e30fe7aaa4de4f50db211574c10fc27",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "required",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-some-js@0.0.1",
       "evidence": {}
     }
   ],
@@ -955,7 +949,6 @@ exports[`integration functional: esbuild latest generated json file: dist/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-esbuild-latest@1.0.0",
       "evidence": {}
     }
   },
@@ -976,7 +969,6 @@ exports[`integration functional: esbuild latest generated json file: dist/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
       "evidence": {
         "licenses": [
           {
@@ -1000,7 +992,6 @@ exports[`integration functional: esbuild latest generated json file: dist/bom.js
       "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "excluded",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
       "evidence": {}
     }
   ],
@@ -1119,7 +1110,6 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-esbuild-lowest@1.0.0",
       "evidence": {}
     }
   },
@@ -1140,7 +1130,6 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
       "evidence": {
         "licenses": [
           {
@@ -1172,7 +1161,6 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-unused-package@0.0.1",
       "evidence": {}
     },
     {
@@ -1183,7 +1171,6 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
       "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "required",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
       "evidence": {}
     }
   ],
@@ -1291,8 +1278,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
       "name": "cyclonedx-eslint-testbed-juice-shop-frontend",
       "group": "@cyclonedx",
       "version": "19.2.0-SNAPSHOT",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-juice-shop-frontend@19.2.0-SNAPSHOT"
+      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
     }
   },
   "components": [
@@ -1416,7 +1402,6 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/codemirror-solidity@0.2.5",
       "externalReferences": [
         {
           "url": "https://github.com/alincode/codemirror-solidity#readme",
@@ -14826,7 +14811,6 @@ exports[`integration functional: no tree-shaking generated json file: dist/bom.j
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-no-treeshaking@1.0.0",
       "evidence": {}
     }
   },
@@ -14847,7 +14831,6 @@ exports[`integration functional: no tree-shaking generated json file: dist/bom.j
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
       "evidence": {
         "licenses": [
           {
@@ -14871,7 +14854,6 @@ exports[`integration functional: no tree-shaking generated json file: dist/bom.j
       "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "required",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
       "evidence": {}
     }
   ],
@@ -15093,7 +15075,6 @@ exports[`integration functional: react19 on bun generated json file: dist/bom.js
       "group": "@cyclonedx",
       "version": "0.1.0",
       "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-react19-bun@0.1.0",
       "evidence": {}
     }
   },
@@ -15367,7 +15348,6 @@ exports[`integration functional: runtime-dependencies are external generated jso
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-with-externals@1.0.0",
       "evidence": {}
     }
   },
@@ -15480,7 +15460,6 @@ exports[`integration functional: simple typescript bundling on npm generated jso
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-typescript-npm@1.0.0",
       "evidence": {}
     }
   },
@@ -15501,7 +15480,6 @@ exports[`integration functional: simple typescript bundling on npm generated jso
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
       "evidence": {
         "licenses": [
           {
@@ -15525,7 +15503,6 @@ exports[`integration functional: simple typescript bundling on npm generated jso
       "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "excluded",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
       "evidence": {}
     }
   ],
@@ -15649,7 +15626,6 @@ exports[`integration functional: simple typescript bundling on yarn generated js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-typescript-yarn@1.0.0",
       "evidence": {}
     }
   },
@@ -15662,7 +15638,6 @@ exports[`integration functional: simple typescript bundling on yarn generated js
       "bom-ref": "4407577ae52a8e0b1426675fc484aef8bcb0be37d7d025e1bf12586b8e5056ce",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "excluded",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
       "evidence": {}
     },
     {
@@ -15681,7 +15656,6 @@ exports[`integration functional: simple typescript bundling on yarn generated js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
       "evidence": {
         "licenses": [
           {

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -15791,8 +15791,7 @@ exports[`integration package \`@hookform/resolvers\` with shipped sub-package \`
             "acknowledgement": "declared"
           }
         }
-      ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-hookform-resolvers-subpath@1.0.0"
+      ]
     }
   },
   "components": [
@@ -15917,8 +15916,7 @@ exports[`integration package \`@hookform/resolvers\` with shipped sub-package \`
             "acknowledgement": "declared"
           }
         }
-      ],
-      "purl": "pkg:npm/%40hookform/resolvers%2Fzod@1.0.0"
+      ]
     },
     {
       "type": "library",

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -14986,7 +14986,7 @@ exports[`integration functional: package name is non-standard generated json fil
       "group": "@cyclonedx",
       "version": "1.0.0",
       "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "description": "Example using a name that is not standard to https://www.npmjs.com/",
+      "description": "Example using a name that is non-standard to https://www.npmjs.com/",
       "licenses": [
         {
           "license": {
@@ -14995,7 +14995,6 @@ exports[`integration functional: package name is non-standard generated json fil
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-with-non-standard-name%2Ftestbed@1.0.0",
       "evidence": {}
     }
   },


### PR DESCRIPTION


### Description


* Fixed
  * Don't emit purls for private package without reachability qualifiers
  * Don't emit purls for non-standard package names without reachability qualifiers 

- fixes #193

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX//cyclonedx-esbuild/blob/main/CONTRIBUTING.md) guidelines
