### PR TITLE
build: split build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ permissions: {}
 env:
   REPORTS_DIR: CI_reports
   PACKED_DIR: CI_packed
+  DIST_DIR: dist
+  BUILD_ARTIFACT: dist
   PACKED_ARTIFACT: packed
   NODE_ACTIVE_LTS: "24"  # https://nodejs.org/en/about/releases/
 
@@ -94,16 +96,68 @@ jobs:
           echo "::add-mask::$AUTH_B64"
           git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $AUTH_B64" \
             push --follow-tags "https://github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
-  publish-NPMJS:
-    needs:
-      - "bump"
-    name: publish NPMJS
+  dep-test:
+    name: dependency tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      id-token: write  # Enables provenance signing via OIDC
-    env:
-      NPMJS_RELEASE_TAG: ${{ github.event.inputs.prerelease == 'true' && 'unstable-prerelease' || 'latest' }}
+    steps:
+      - name: Checkout code
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.bump.outputs.version }}
+          persist-credentials: false
+      - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
+        # see https://github.com/actions/setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_ACTIVE_LTS }}
+          package-manager-cache: false
+      - name: setup dep-tester
+        run: |
+          npm run -- dev-setup:tools:test-dependencies --ignore-scripts --loglevel=silly
+      - name: run tests
+        run: |
+          npm run -- test:dependencies
+  build:
+    needs:
+      - "bump"
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.bump.outputs.version }}
+          persist-credentials: false
+      - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
+        # see https://github.com/actions/setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_ACTIVE_LTS }}
+          package-manager-cache: false
+      - name: setup project
+        run: |
+          npm install --ignore-scripts --include=optional --loglevel=silly
+      - name: build project
+        run: |
+          npm run build
+      - name: artifact build result
+        # see https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}/
+          if-no-files-found: error
+  quick-test:
+    needs:
+      - "build"
+    name: quick tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # setup-tests test
     steps:
       - name: Checkout code
         # see https://github.com/actions/checkout
@@ -131,15 +185,50 @@ jobs:
       - name: setup project
         run: |
           npm install --ignore-scripts --include=optional --loglevel=silly
-      - name: install tools
+      - name: setup tests
         run: |
-          echo "::group::install code-style deps"
-          npm run -- dev-setup:tools:code-style --ignore-scripts --loglevel=silly
-          echo "::endgroup::"
-          echo "::group::install test-dependencies deps"
-          npm run -- dev-setup:tools:test-dependencies --ignore-scripts --loglevel=silly
-          echo "::endgroup::"
-      # no explicit npm build. if a build is required, it should be configured as prepublish/prepublishOnly script of npm.
+          npm run -- setup-tests
+      - name: fetch build result
+        # see https://github.com/actions/download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}
+      - name: run tests
+        run: |
+          npm run -- test:jest
+  publish-NPMJS:
+    needs:
+      - "bump"
+      - "build"
+      - "dep-test"
+      - "quick-test"
+    name: publish NPMJS
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write  # Enables provenance signing via OIDC
+    env:
+      NPMJS_RELEASE_TAG: ${{ github.event.inputs.prerelease == 'true' && 'unstable-prerelease' || 'latest' }}
+    steps:
+      - name: Checkout code
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.bump.outputs.version }}
+          persist-credentials: false
+      - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
+        # see https://github.com/actions/setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_ACTIVE_LTS }}
+          package-manager-cache: false
+      - name: fetch build result
+        # see https://github.com/actions/download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}
       - name: publish to NPMJS as "${{ env.NPMJS_RELEASE_TAG }}"
         run: >
           npm publish

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "build": "tsc -b ./tsconfig.json",
     "build-dev": "npm run -- build --sourceMap",
     "prepublish": "npm run build",
-    "prepublishOnly": "run-s -lc build setup-tests test",
     "setup-tests": "node tests/setup.js",
     "test": "run-p --aggregate-output -lc 'test:*'",
     "test:jest": "c8 jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cyclonedx-esbuild",
-  "version": "1.4.3-rc.0",
+  "version": "1.4.3-rc.1",
   "description": "Create CycloneDX Software Bill of Materials (SBOM) from projects built with esbuild or Bun.",
   "license": "Apache-2.0",
   "copyright": "Copyright OWASP Foundation",


### PR DESCRIPTION
split the build workflow
to minimize permissions on test runners and such