### PR TITLE
fix: bom-ref values are component-based

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 <!-- add unreleased items here -->
 
 * Fix
-  * Reproducible BomRef values (via [#])
+  * Reproducible BomRef values (via [#200])
 
-[#]: 
+[#200]: https://github.com/CycloneDX/cyclonedx-esbuild/pull/200
 
 ## 1.4.3 - 2026-08-10
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* Fix
+  * Reproducible BomRef values (via [#])
+
+[#]: 
+
 ## 1.4.3 - 2026-08-10
 
 Maintenance release.

--- a/examples/plugin-bun/package.json
+++ b/examples/plugin-bun/package.json
@@ -6,6 +6,16 @@
   "engines": {
     "bun": "*"
   },
+  "devEngines": {
+    "runtime": {
+      "name": "bun",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "bun",
+      "onFail": "error"
+    }
+  },
   "main": "./dist/app.js",
   "dependencies": {
     "@popperjs/core": "^2",

--- a/examples/plugin-bun/sbom-results/sbom.json
+++ b/examples/plugin-bun/sbom-results/sbom.json
@@ -15,7 +15,7 @@
           "type": "library",
           "name": "cyclonedx-esbuild",
           "group": "@cyclonedx",
-          "version": "1.4.1",
+          "version": "1.4.3",
           "author": "Jan Kowalleck",
           "description": "Create CycloneDX Software Bill of Materials (SBOM) from projects built with esbuild or Bun.",
           "licenses": [
@@ -82,7 +82,7 @@
       "name": "cyclonedx-esbuild-example-plugin-bun",
       "group": "@cyclonedx",
       "version": "0.1.0-dev",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-esbuild-example-plugin-bun@0.1.0-dev#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "demo integration as a plugin for bun",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-esbuild-example-plugin-bun@0.1.0-dev",
       "evidence": {}
@@ -94,7 +94,7 @@
       "name": "core",
       "group": "@popperjs",
       "version": "2.11.8",
-      "bom-ref": "e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902",
+      "bom-ref": "@popperjs/core@2.11.8#e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902",
       "author": "Federico Zivolo",
       "description": "Tooltip and Popover Positioning Engine",
       "scope": "required",
@@ -143,7 +143,7 @@
       "type": "library",
       "name": "bootstrap",
       "version": "5.3.8",
-      "bom-ref": "f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
+      "bom-ref": "bootstrap@5.3.8#f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
       "author": "The Bootstrap Authors",
       "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
       "scope": "required",
@@ -191,18 +191,18 @@
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx/cyclonedx-esbuild-example-plugin-bun@0.1.0-dev#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a"
+        "bootstrap@5.3.8#f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a"
       ]
     },
     {
-      "ref": "e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
+      "ref": "@popperjs/core@2.11.8#e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
     },
     {
-      "ref": "f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
+      "ref": "bootstrap@5.3.8#f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
       "dependsOn": [
-        "e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
+        "@popperjs/core@2.11.8#e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
       ]
     }
   ]

--- a/examples/plugin-esbuild/sbom-results/sbom.json
+++ b/examples/plugin-esbuild/sbom-results/sbom.json
@@ -20,7 +20,7 @@
           "type": "library",
           "name": "cyclonedx-esbuild",
           "group": "@cyclonedx",
-          "version": "1.4.1",
+          "version": "1.4.3",
           "author": "Jan Kowalleck",
           "description": "Create CycloneDX Software Bill of Materials (SBOM) from projects built with esbuild or Bun.",
           "licenses": [
@@ -87,7 +87,7 @@
       "name": "cyclonedx-esbuild-example-plugin-esbuild",
       "group": "@cyclonedx",
       "version": "0.1.0-dev",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-esbuild-example-plugin-esbuild@0.1.0-dev#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "demo integration as a plugin for esbuild",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-esbuild-example-plugin-esbuild@0.1.0-dev",
       "evidence": {}
@@ -99,7 +99,7 @@
       "name": "core",
       "group": "@popperjs",
       "version": "2.11.8",
-      "bom-ref": "e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902",
+      "bom-ref": "@popperjs/core@2.11.8#e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902",
       "author": "Federico Zivolo",
       "description": "Tooltip and Popover Positioning Engine",
       "scope": "required",
@@ -148,7 +148,7 @@
       "type": "library",
       "name": "bootstrap",
       "version": "5.3.8",
-      "bom-ref": "f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
+      "bom-ref": "bootstrap@5.3.8#f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
       "author": "The Bootstrap Authors",
       "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
       "scope": "required",
@@ -196,18 +196,18 @@
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx/cyclonedx-esbuild-example-plugin-esbuild@0.1.0-dev#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a"
+        "bootstrap@5.3.8#f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a"
       ]
     },
     {
-      "ref": "e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
+      "ref": "@popperjs/core@2.11.8#e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
     },
     {
-      "ref": "f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
+      "ref": "bootstrap@5.3.8#f69c6dbe42f2df903ae6a87ae6491bde586b4ad9a4cd16deeb5421a085e5bc9a",
       "dependsOn": [
-        "e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
+        "@popperjs/core@2.11.8#e2b18ca226c83eb39d4534e5c9118962ac64657141b0efde7474cc084f839902"
       ]
     }
   ]

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -80,7 +80,7 @@ export class BomBuilder {
     if ( outputReproducible ) {
       componentsPkg.forEach((component, pkgPath) => {
         /* eslint-disable-next-line no-param-reassign -- ack */
-        component.bomRef.value = mkRelativePathReproducibleHash(buildWorkingDir, pkgPath)
+        component.bomRef.value += `#${mkRelativePathReproducibleHash(buildWorkingDir, pkgPath)}`
       })
     }
 

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -80,7 +80,7 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
       "name": "cyclonedx-eslint-testbed-angular20-npm",
       "group": "@cyclonedx",
       "version": "0.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-angular20-npm@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-angular20-npm@0.0.0",
       "evidence": {}
     }
@@ -88,12 +88,11 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
   "components": [
     {
       "type": "library",
-      "name": "platform-browser",
+      "name": "cdk",
       "group": "@angular",
       "version": "20.2.2",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
+      "bom-ref": "@angular/cdk@20.2.2#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+      "description": "Angular Material Component Development Kit",
       "scope": "required",
       "licenses": [
         {
@@ -103,56 +102,7 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/platform-browser@20.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNSBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "material",
-      "group": "@angular",
-      "version": "20.2.2",
-      "bom-ref": "2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
-      "description": "Angular Material",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/material@20.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
+      "purl": "pkg:npm/%40angular/cdk@20.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
       "externalReferences": [
         {
           "url": "https://github.com/angular/components/issues",
@@ -187,140 +137,10 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
     },
     {
       "type": "library",
-      "name": "zone.js",
-      "version": "0.15.1",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.15.1?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNSBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "cyclonedx-eslint-testing-custom-package",
-      "group": "@cyclonedx",
-      "version": "0.0.1",
-      "bom-ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
-      "description": "this is a dummy package for showcasing purposes only.\\n",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "name": "dummy-license",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.txt",
-              "text": {
-                "content": "SlVTVCBBIERVTU1ZIExJQ0VOU0UgVEVYVAoKTG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gUGVsbGVudGVzcXVlIHRlbXB1cyBwcmV0aXVtIGFudGUgaGVuZHJlcml0IHBoYXJldHJhLiBDdXJhYml0dXIgYmxhbmRpdCBhdWN0b3IgbWFnbmEgZXQgcHVsdmluYXIuIFZpdmFtdXMgZXVpc21vZCBtYXVyaXMgc2l0IGFtZXQgdGluY2lkdW50IHRpbmNpZHVudC4gTmFtIGxlY3R1cyB0b3J0b3IsIHVsdHJpY2VzIHF1aXMgdWx0cmljZXMgYXQsIHBoYXJldHJhIGluIGxhY3VzLiBOdWxsYSBsb2JvcnRpcyBudW5jIHNpdCBhbWV0IHRvcnRvciBibGFuZGl0IHNhZ2l0dGlzLiBJbiBlbGVtZW50dW0gc2NlbGVyaXNxdWUgZmV1Z2lhdC4gUGVsbGVudGVzcXVlIGVsZWlmZW5kIHZlbmVuYXRpcyBjb25zZWN0ZXR1ci4gU3VzcGVuZGlzc2UgcG90ZW50aS4gTWF1cmlzIHBsYWNlcmF0LCBtaSBpbiBhdWN0b3IgbG9ib3J0aXMsIHJpc3VzIGxvcmVtIHVsbGFtY29ycGVyIHNhcGllbiwgcXVpcyBwbGFjZXJhdCBlcm9zIGFudGUgbm9uIGxvcmVtLiBOYW0gdGVtcHVzIGNvbmd1ZSBkaWFtIGZpbmlidXMgcnV0cnVtLiBQaGFzZWxsdXMgdHJpc3RpcXVlIHNhcGllbiBpbiBtYXNzYSBhbGlxdWFtLCB2aXRhZSBsdWN0dXMgbWV0dXMgY29uZ3VlLiBRdWlzcXVlIGVsZW1lbnR1bSBhbGlxdWFtIHRpbmNpZHVudC4K",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.8.2",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.8.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://rxjs.dev",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.txt",
-              "text": {
-                "content": "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "20.2.2",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@20.2.2#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "scope": "required",
@@ -367,59 +187,10 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
     },
     {
       "type": "library",
-      "name": "tslib",
-      "version": "2.8.1",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.txt",
-              "text": {
-                "content": "Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "20.2.2",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "scope": "required",
@@ -469,7 +240,7 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
       "name": "forms",
       "group": "@angular",
       "version": "20.2.2",
-      "bom-ref": "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
+      "bom-ref": "@angular/forms@20.2.2#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
       "author": "angular",
       "description": "Angular - directives and services for creating forms",
       "scope": "required",
@@ -516,11 +287,11 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
     },
     {
       "type": "library",
-      "name": "cdk",
+      "name": "material",
       "group": "@angular",
       "version": "20.2.2",
-      "bom-ref": "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
-      "description": "Angular Material Component Development Kit",
+      "bom-ref": "@angular/material@20.2.2#2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
+      "description": "Angular Material",
       "scope": "required",
       "licenses": [
         {
@@ -530,7 +301,7 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/cdk@20.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
+      "purl": "pkg:npm/%40angular/material@20.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
       "externalReferences": [
         {
           "url": "https://github.com/angular/components/issues",
@@ -565,14 +336,243 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
     },
     {
       "type": "library",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "20.2.2",
+      "bom-ref": "@angular/platform-browser@20.2.2#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/platform-browser@20.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNSBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "cyclonedx-eslint-testing-custom-package",
+      "group": "@cyclonedx",
+      "version": "0.0.1",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
+      "description": "this is a dummy package for showcasing purposes only.\\n",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "name": "dummy-license",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1",
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.txt",
+              "text": {
+                "content": "SlVTVCBBIERVTU1ZIExJQ0VOU0UgVEVYVAoKTG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gUGVsbGVudGVzcXVlIHRlbXB1cyBwcmV0aXVtIGFudGUgaGVuZHJlcml0IHBoYXJldHJhLiBDdXJhYml0dXIgYmxhbmRpdCBhdWN0b3IgbWFnbmEgZXQgcHVsdmluYXIuIFZpdmFtdXMgZXVpc21vZCBtYXVyaXMgc2l0IGFtZXQgdGluY2lkdW50IHRpbmNpZHVudC4gTmFtIGxlY3R1cyB0b3J0b3IsIHVsdHJpY2VzIHF1aXMgdWx0cmljZXMgYXQsIHBoYXJldHJhIGluIGxhY3VzLiBOdWxsYSBsb2JvcnRpcyBudW5jIHNpdCBhbWV0IHRvcnRvciBibGFuZGl0IHNhZ2l0dGlzLiBJbiBlbGVtZW50dW0gc2NlbGVyaXNxdWUgZmV1Z2lhdC4gUGVsbGVudGVzcXVlIGVsZWlmZW5kIHZlbmVuYXRpcyBjb25zZWN0ZXR1ci4gU3VzcGVuZGlzc2UgcG90ZW50aS4gTWF1cmlzIHBsYWNlcmF0LCBtaSBpbiBhdWN0b3IgbG9ib3J0aXMsIHJpc3VzIGxvcmVtIHVsbGFtY29ycGVyIHNhcGllbiwgcXVpcyBwbGFjZXJhdCBlcm9zIGFudGUgbm9uIGxvcmVtLiBOYW0gdGVtcHVzIGNvbmd1ZSBkaWFtIGZpbmlidXMgcnV0cnVtLiBQaGFzZWxsdXMgdHJpc3RpcXVlIHNhcGllbiBpbiBtYXNzYSBhbGlxdWFtLCB2aXRhZSBsdWN0dXMgbWV0dXMgY29uZ3VlLiBRdWlzcXVlIGVsZW1lbnR1bSBhbGlxdWFtIHRpbmNpZHVudC4K",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
       "name": "cyclonedx-eslint-testing-reexport-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "excluded",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
       "evidence": {}
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.8.2",
+      "bom-ref": "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.8.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.txt",
+              "text": {
+                "content": "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.8.1",
+      "bom-ref": "tslib@2.8.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.txt",
+              "text": {
+                "content": "Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.15.1",
+      "bom-ref": "zone.js@0.15.1#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.15.1?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNSBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
     },
     {
       "type": "library",
@@ -603,94 +603,94 @@ exports[`integration functional: angular20 on npm generated json file: dist/firs
   ],
   "dependencies": [
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/cdk@20.2.2#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@20.2.2#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
+      "ref": "@angular/common@20.2.2#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
-        "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26"
+        "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
+      "ref": "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "dependsOn": [
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+      ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@angular/forms@20.2.2#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
-        "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+        "@angular/common@20.2.2#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+      ]
+    },
+    {
+      "ref": "@angular/material@20.2.2#2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
+      "dependsOn": [
+        "@angular/cdk@20.2.2#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+        "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/forms@20.2.2#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556"
+      ]
+    },
+    {
+      "ref": "@angular/platform-browser@20.2.2#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "dependsOn": [
+        "@angular/common@20.2.2#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+      ]
+    },
+    {
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-angular20-npm@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "dependsOn": [
+        "@angular/cdk@20.2.2#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+        "@angular/common@20.2.2#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.2.2#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/material@20.2.2#2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
+        "@angular/platform-browser@20.2.2#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
         "VirtualComponent angular:polyfills:angular:polyfills",
         "VirtualComponent angular:styles/global:styles"
       ]
     },
     {
-      "ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
       ]
     },
     {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "tslib@2.8.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
-    },
-    {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-      "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
-      ]
-    },
-    {
-      "ref": "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
-      "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
-      ]
-    },
-    {
-      "ref": "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
-      "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
-      ]
-    },
-    {
-      "ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
-      "dependsOn": [
-        "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
-      ]
+      "ref": "tslib@2.8.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
     },
     {
       "ref": "VirtualComponent angular:polyfills:angular:polyfills",
       "dependsOn": [
-        "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
+        "zone.js@0.15.1#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
       ]
     },
     {
       "ref": "VirtualComponent angular:styles/global:styles",
       "dependsOn": [
-        "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
+        "@cyclonedx/cyclonedx-eslint-testbed-angular20-npm@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
       ]
+    },
+    {
+      "ref": "zone.js@0.15.1#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
     }
   ]
 }"
@@ -786,7 +786,7 @@ exports[`integration functional: entryPoints are external generated json file: d
       "name": "cyclonedx-eslint-testbed-with-external-entrypoints",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-with-external-entrypoints@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "Example using esbuild with external entryPoints",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-with-external-entrypoints@1.0.0",
       "evidence": {}
@@ -798,7 +798,7 @@ exports[`integration functional: entryPoints are external generated json file: d
       "name": "cyclonedx-eslint-testing-custom-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
       "description": "this is a dummy package for showcasing purposes only.\\n",
       "scope": "required",
       "licenses": [
@@ -830,7 +830,7 @@ exports[`integration functional: entryPoints are external generated json file: d
       "name": "cyclonedx-eslint-testing-some-js",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "afdd713844bfa0f7a517f5c864728f1d9e30fe7aaa4de4f50db211574c10fc27",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-some-js@0.0.1#afdd713844bfa0f7a517f5c864728f1d9e30fe7aaa4de4f50db211574c10fc27",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "required",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-some-js@0.0.1",
@@ -839,17 +839,17 @@ exports[`integration functional: entryPoints are external generated json file: d
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-with-external-entrypoints@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
-        "afdd713844bfa0f7a517f5c864728f1d9e30fe7aaa4de4f50db211574c10fc27"
+        "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
+        "@cyclonedx/cyclonedx-eslint-testing-some-js@0.0.1#afdd713844bfa0f7a517f5c864728f1d9e30fe7aaa4de4f50db211574c10fc27"
       ]
     },
     {
-      "ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
     },
     {
-      "ref": "afdd713844bfa0f7a517f5c864728f1d9e30fe7aaa4de4f50db211574c10fc27"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-some-js@0.0.1#afdd713844bfa0f7a517f5c864728f1d9e30fe7aaa4de4f50db211574c10fc27"
     }
   ]
 }"
@@ -945,7 +945,7 @@ exports[`integration functional: esbuild latest generated json file: dist/bom.js
       "name": "cyclonedx-eslint-testbed-esbuild-latest",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-esbuild-latest@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "Example using esbuild wit the latest supported version",
       "licenses": [
         {
@@ -965,7 +965,7 @@ exports[`integration functional: esbuild latest generated json file: dist/bom.js
       "name": "cyclonedx-eslint-testing-custom-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
       "description": "this is a dummy package for showcasing purposes only.\\n",
       "scope": "required",
       "licenses": [
@@ -997,7 +997,7 @@ exports[`integration functional: esbuild latest generated json file: dist/bom.js
       "name": "cyclonedx-eslint-testing-reexport-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "excluded",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
@@ -1006,18 +1006,18 @@ exports[`integration functional: esbuild latest generated json file: dist/bom.js
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-esbuild-latest@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0"
+        "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0"
       ]
     },
     {
-      "ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
     },
     {
-      "ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "dependsOn": [
-        "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+        "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
       ]
     }
   ]
@@ -1109,7 +1109,7 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
       "name": "cyclonedx-eslint-testbed-esbuild-lowest",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-esbuild-lowest@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "Example using esbuild wit the lowest supported version",
       "licenses": [
         {
@@ -1129,7 +1129,7 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
       "name": "cyclonedx-eslint-testing-custom-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
       "description": "this is a dummy package for showcasing purposes only.\\n",
       "scope": "required",
       "licenses": [
@@ -1158,10 +1158,21 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
     },
     {
       "type": "library",
+      "name": "cyclonedx-eslint-testing-reexport-package",
+      "group": "@cyclonedx",
+      "version": "0.0.1",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "description": "this is a dummy package for showcasing purposes only.",
+      "scope": "required",
+      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
+      "evidence": {}
+    },
+    {
+      "type": "library",
       "name": "cyclonedx-eslint-testing-unused-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "edb24c99c0b34b54504b1427abbf4d88c1f41af337010b8df77f7de36fa712d8",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-unused-package@0.0.1#edb24c99c0b34b54504b1427abbf4d88c1f41af337010b8df77f7de36fa712d8",
       "description": "this is a dummy package for showcasing purposes only. It shall never be used.",
       "scope": "required",
       "licenses": [
@@ -1174,38 +1185,27 @@ exports[`integration functional: esbuild lowest generated json file: dist/bom.js
       ],
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-unused-package@0.0.1",
       "evidence": {}
-    },
-    {
-      "type": "library",
-      "name": "cyclonedx-eslint-testing-reexport-package",
-      "group": "@cyclonedx",
-      "version": "0.0.1",
-      "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
-      "description": "this is a dummy package for showcasing purposes only.",
-      "scope": "required",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
-      "evidence": {}
     }
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-esbuild-lowest@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "edb24c99c0b34b54504b1427abbf4d88c1f41af337010b8df77f7de36fa712d8",
-        "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0"
+        "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+        "@cyclonedx/cyclonedx-eslint-testing-unused-package@0.0.1#edb24c99c0b34b54504b1427abbf4d88c1f41af337010b8df77f7de36fa712d8"
       ]
     },
     {
-      "ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
     },
     {
-      "ref": "edb24c99c0b34b54504b1427abbf4d88c1f41af337010b8df77f7de36fa712d8"
-    },
-    {
-      "ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "dependsOn": [
-        "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+        "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
       ]
+    },
+    {
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-unused-package@0.0.1#edb24c99c0b34b54504b1427abbf4d88c1f41af337010b8df77f7de36fa712d8"
     }
   ]
 }"
@@ -1291,1676 +1291,17 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
       "name": "cyclonedx-eslint-testbed-juice-shop-frontend",
       "group": "@cyclonedx",
       "version": "19.2.0-SNAPSHOT",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-juice-shop-frontend@19.2.0-SNAPSHOT#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-juice-shop-frontend@19.2.0-SNAPSHOT"
     }
   },
   "components": [
     {
       "type": "library",
-      "name": "ng2-file-upload",
-      "version": "9.0.0",
-      "bom-ref": "061ec3972fcd2bf843e949590c0c995be1d6d66f794edcc68d526957eb76d864",
-      "author": "Dmitriy Shekhovtsov",
-      "description": "Angular file uploader",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ng2-file-upload@9.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fvalor-software%2Fng2-file-upload.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/valor-software/ng2-file-upload/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+ssh://git@github.com/valor-software/ng2-file-upload.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/valor-software/ng2-file-upload#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "component-emitter",
-      "version": "1.3.1",
-      "bom-ref": "0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
-      "description": "Event emitter",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/component-emitter@1.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsindresorhus%2Fcomponent-emitter.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/sindresorhus/component-emitter/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/sindresorhus/component-emitter.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/sindresorhus/component-emitter#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "parseuri",
-      "version": "0.0.6",
-      "bom-ref": "11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f",
-      "author": "Gal Koren",
-      "description": "Method that parses a URI and returns an array of its components",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/parseuri@0.0.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fget%2Fparseuri.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/get/parseuri/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/get/parseuri.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/get/parseuri",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "codemirror-solidity",
-      "version": "0.2.5",
-      "bom-ref": "1387fa0e934f50384db142905d7f5c576ad88b3fbf172362ba3b14ee03a6a6f1",
-      "author": "alincode",
-      "description": "codemirror solidity mode",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/codemirror-solidity@0.2.5",
-      "externalReferences": [
-        {
-          "url": "https://github.com/alincode/codemirror-solidity#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "bytes",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-      "author": "Richard Moore",
-      "description": "Bytes utility functions for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/bytes@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbytes",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/bytes",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "minimalistic-assert",
-      "version": "1.0.1",
-      "bom-ref": "1dcf4229ac09993c5669a6bbbd2a2c7781e5cddc8c05791b8007747707c4796d",
-      "description": "minimalistic-assert ===",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "ISC",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/minimalistic-assert@1.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcalvinmetcalf%2Fminimalistic-assert.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/calvinmetcalf/minimalistic-assert/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/calvinmetcalf/minimalistic-assert.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/calvinmetcalf/minimalistic-assert",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "abi",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
-      "author": "Richard Moore",
-      "description": "Utilities and Classes for parsing, formatting and managing Ethereum ABIs.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/abi@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fabi",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/abi",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "free-brands-svg-icons",
-      "group": "@fortawesome",
-      "version": "5.15.4",
-      "bom-ref": "23aeadff4c49ed6fe259ceedace718a1b3a87758bb84f447a7233d6ef697b01a",
-      "author": "Dave Gandy",
-      "description": "The iconic font, CSS, and SVG framework",
-      "scope": "required",
-      "licenses": [
-        {
-          "expression": "(CC-BY-4.0 AND MIT)",
-          "acknowledgement": "declared"
-        }
-      ],
-      "purl": "pkg:npm/%40fortawesome/free-brands-svg-icons@5.15.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://fontawesome.com",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ethers",
-      "version": "5.8.0",
-      "bom-ref": "2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
-      "author": "Richard Moore",
-      "description": "Umbrella package for most common Ethers libraries.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ethers@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fethers",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/ethers",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "properties",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-      "author": "Richard Moore",
-      "description": "Properties utility functions for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/properties@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fproperties",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/properties",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "platform-browser",
-      "group": "@angular",
-      "version": "20.3.17",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/platform-browser@20.3.17?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "pbkdf2",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
-      "author": "Richard Moore",
-      "description": "The PBKDF2 password-pbased key derivation function for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/pbkdf2@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fpbkdf2",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/pbkdf2",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "abstract-provider",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
-      "author": "Richard Moore",
-      "description": "An Abstract Class for describing an Ethereum Provider for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/abstract-provider@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fabstract-provider",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/abstract-provider",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "material",
-      "group": "@angular",
-      "version": "20.2.14",
-      "bom-ref": "2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
-      "description": "Angular Material",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/material@20.2.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/components/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/components.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/angular/components#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "hash",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
-      "author": "Richard Moore",
-      "description": "Hash utility functions for Ethereum.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/hash@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fhash",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/hash",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "inherits",
-      "version": "2.0.4",
-      "bom-ref": "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
-      "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "ISC",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/isaacs/inherits/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/isaacs/inherits.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/isaacs/inherits#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "base64",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
-      "author": "Richard Moore",
-      "description": "Base64 coder.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/base64@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbase64",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/base64",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "bn.js",
-      "version": "5.2.3",
-      "bom-ref": "3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1",
-      "author": "Fedor Indutny",
-      "description": "Big number implementation in pure javascript",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/bn.js@5.2.3?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Findutny%2Fbn.js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/indutny/bn.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+ssh://git@github.com/indutny/bn.js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/indutny/bn.js",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "fontawesome-svg-core",
-      "group": "@fortawesome",
-      "version": "1.2.36",
-      "bom-ref": "3e0945a272ea197886256c13e5d9d01ea14c18e8a345d0b5a14c524d3c316053",
-      "author": "Dave Gandy",
-      "description": "The iconic font, CSS, and SVG framework",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40fortawesome/fontawesome-svg-core@1.2.36?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://fontawesome.com",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "hash.js",
-      "version": "1.1.7",
-      "bom-ref": "419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91",
-      "author": "Fedor Indutny",
-      "description": "Various hash functions that could be run by both browser and node",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/hash.js@1.1.7?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Findutny%2Fhash.js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/indutny/hash.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+ssh://git@github.com/indutny/hash.js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/indutny/hash.js",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "has-cors",
-      "version": "1.1.0",
-      "bom-ref": "4463ae507d574f1c1e49f9e4523d3e45d2fb18df2ff83b1153c23aca4862db35",
-      "author": "Nathan Rajlich",
-      "description": "Detects support for Cross-Origin Resource Sharing",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/has-cors@1.1.0?vcs_url=git%3A%2F%2Fgithub.com%2Fcomponent%2Fhas-cors.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/component/has-cors/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/component/has-cors.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/component/has-cors#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "yeast",
-      "version": "0.1.2",
-      "bom-ref": "460939b68f8053fe278cb6210f7b2d9187940178fca9abf270d11ff80bda5aa0",
-      "author": "Arnout Kazemier",
-      "description": "Tiny but linear growing unique id generator",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/yeast@0.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Funshiftio%2Fyeast.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/unshiftio/yeast/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/unshiftio/yeast.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/unshiftio/yeast",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "canvas-confetti",
-      "version": "1.9.4",
-      "bom-ref": "470080acde1191c2f60340adb57cf459ed26b92c63755bf042f1cbb73fd164d6",
-      "author": "Kiril Vatev",
-      "description": "performant confetti animation in the browser",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "ISC",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/canvas-confetti@1.9.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcatdad%2Fcanvas-confetti.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/catdad/canvas-confetti/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/catdad/canvas-confetti.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/catdad/canvas-confetti#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "engine.io-parser",
-      "version": "4.0.3",
-      "bom-ref": "49646800769b71f6867412afd9659b95d3915a506b240b81ed1f154f01ba25cb",
-      "description": "Parser for the client for the realtime Engine",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/engine.io-parser@4.0.3?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fsocketio%2Fengine.io-parser.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/socketio/engine.io-parser/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+ssh://git@github.com/socketio/engine.io-parser.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/socketio/engine.io-parser",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "json-wallets",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
-      "author": "Richard Moore",
-      "description": "Wallet management utilities for KeyStore and Crowdsale JSON wallets.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/json-wallets@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fjson-wallets",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/json-wallets",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "bignumber",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-      "author": "Richard Moore",
-      "description": "BigNumber library used in ethers.js.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/bignumber@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbignumber",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/bignumber",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "logger",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-      "author": "Richard Moore",
-      "description": "Logger utility functions for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/logger@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Flogger",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/logger",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ngx-codemirror",
-      "group": "@ctrl",
-      "version": "7.0.0",
-      "bom-ref": "54f3746bdae3b18da934798c490da1b34044aa8fd98714521bb76e38fd574568",
-      "description": "CodeMirror wrapper for Angular",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ctrl/ngx-codemirror@7.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fscttcper%2Fngx-codemirror.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/scttcper/ngx-codemirror/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/scttcper/ngx-codemirror.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/scttcper/ngx-codemirror",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "solidity",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "5536aef1348089387c04172edddfa56e2ae144f384aa4871c035ab0d94621a47",
-      "author": "Richard Moore",
-      "description": "Solidity coder for non-standard (tight) packing.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/solidity@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fsolidity",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/solidity",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "bech32",
-      "version": "1.1.4",
-      "bom-ref": "58e67da2ac79d3a7fb5463e0e89caa3346e3879ca25c384fc9a58b950e81cea0",
-      "description": "Bech32 encoding / decoding",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/bech32@1.1.4?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fbitcoinjs%2Fbech32.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/bitcoinjs/bech32/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+ssh://git@github.com/bitcoinjs/bech32.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/bitcoinjs/bech32#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "qrcode",
-      "version": "1.5.4",
-      "bom-ref": "593e2111acde3c2317ba496deb365ec7f1c6b3a8783dd53ed9572947c1a19079",
-      "author": "Ryan Day",
-      "description": "QRCode / 2d Barcode api with both server side and client side support using canvas",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/qrcode@1.5.4?vcs_url=git%3A%2F%2Fgithub.com%2Fsoldair%2Fnode-qrcode.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/soldair/node-qrcode/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/soldair/node-qrcode.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "http://github.com/soldair/node-qrcode",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zone.js",
-      "version": "0.15.1",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.15.1?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "wordlists",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6",
-      "author": "Richard Moore",
-      "description": "Word lists for BIP39 wallets.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/wordlists@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fwordlists",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/wordlists",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "signing-key",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
-      "author": "Richard Moore",
-      "description": "Elliptic curve library functions for the secp256k1 curve.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/signing-key@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fsigning-key",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/signing-key",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ng-gallery",
-      "version": "12.0.0",
-      "bom-ref": "5e91ea783d620d2fd4ea7a5ec9e85d4c8c194e2f9c758a2a47893e4d100b9372",
-      "author": "Murhaf Sousli",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ng-gallery@12.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fmurhafsousli%2Fngx-gallery.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/murhafsousli/ngx-gallery/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/murhafsousli/ngx-gallery.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://ngx-gallery.netlify.app/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ng-qrcode",
-      "version": "20.0.1",
-      "bom-ref": "5ee3fef5d3e4bd3b22d71ad1e6126d725035e7ad5f4f4c977309af050e7ed6f8",
-      "author": "Michael Nahkies",
-      "description": "Simple AOT compatible QR code generator for your Angular project.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ng-qrcode@20.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmnahkies%2Fng-qrcode.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/mnahkies/ng-qrcode/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/mnahkies/ng-qrcode.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/mnahkies/ng-qrcode#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "base64-arraybuffer",
-      "version": "0.1.4",
-      "bom-ref": "668fbe027e327ad3dae761769c6811220166b2e4087fcd0731a4599b571774f4",
-      "author": "Niklas von Hertzen",
-      "description": "Encode/decode base64 data into ArrayBuffers",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared",
-            "url": "https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT"
-          }
-        }
-      ],
-      "purl": "pkg:npm/base64-arraybuffer@0.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fniklasvh%2Fbase64-arraybuffer.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/niklasvh/base64-arraybuffer/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/niklasvh/base64-arraybuffer.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/niklasvh/base64-arraybuffer",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "http-loader",
-      "group": "@ngx-translate",
-      "version": "8.0.0",
-      "bom-ref": "696641cb855cdee93723c8240382c89a8306a582d3991f0477fc57308d2d8014",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "name": "SEE LICENSE IN LICENSE",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ngx-translate/http-loader@8.0.0"
-    },
-    {
-      "type": "library",
-      "name": "font-mfizz",
-      "version": "2.4.1",
-      "bom-ref": "6a0d1d6f94e6c564ed811d8e12383096c32bc5be56ee8ec1348cc932765b57a5",
-      "author": "Fizzed, Inc.",
-      "description": "Font Mfizz - Vector Icons for Technology and Software Geeks ===========================================================",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/font-mfizz@2.4.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffizzed%2Ffont-mfizz.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/fizzed/font-mfizz/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/fizzed/font-mfizz.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "http://fizzed.com/oss/font-mfizz",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "cookieconsent",
-      "version": "3.1.1",
-      "bom-ref": "70465b851954084600d4d20d0e95204b6741f5a109d78a6f967612fb72974d70",
-      "author": "Osano, Inc., a Public Benefit Corporation",
-      "description": "Osano cookie consent tool.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/cookieconsent@3.1.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fosano%2Fcookieconsent.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/osano/cookieconsent/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/osano/cookieconsent.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "http://cookieconsent.osano.com/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "diff-match-patch",
-      "version": "1.0.5",
-      "bom-ref": "707c94303cf21f2f18fbd2e689f593e0dd2dbeb2cfb65df8e62abc3917f3afd3",
-      "description": "npm package for https://github.com/google/diff-match-patch",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/diff-match-patch@1.0.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FJackuB%2Fdiff-match-patch.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/JackuB/diff-match-patch/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/JackuB/diff-match-patch.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/JackuB/diff-match-patch#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "material-icons",
-      "version": "0.3.1",
-      "bom-ref": "71cfcf50345fafd2898e8bf30ca83b02511aed3de0296baec389acb50b5798cc",
-      "description": "Material design icon font and CSS framework for self hosting the icons.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/material-icons@0.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmarella%2Fmaterial-icons.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/marella/material-icons/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/marella/material-icons.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://marella.github.io/material-icons/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "transactions",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-      "author": "Richard Moore",
-      "description": "Utilities for decoding and encoding Ethereum transaction for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/transactions@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Ftransactions",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/transactions",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "socket.io-client",
-      "version": "3.1.3",
-      "bom-ref": "782d1c52d92feccc4f974775dbac70403aee3f7762a947388268d2ca320c30c8",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/socket.io-client@3.1.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsocketio%2Fsocket.io-client.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/socketio/socket.io-client/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/socketio/socket.io-client.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/socketio/socket.io-client#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "parseqs",
-      "version": "0.0.6",
-      "bom-ref": "7c49e48d5f65924f5e8731ac61343484eacef2248600f5050c75e4737fde12eb",
-      "author": "Gal Koren",
-      "description": "Provides methods for parsing a query string into an object, and vice versa.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/parseqs@0.0.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fget%2Fquerystring.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/get/querystring/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/get/querystring.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/get/querystring",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "solidity-browser-compiler",
-      "version": "1.1.0",
-      "bom-ref": "7f785beb037a50a59c946f3bb834293e69ab22dbb1682a86fa0528a6c4f2c790",
-      "author": "Nikola Bozin",
-      "description": "Package for compiling solidity code in the browser.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/solidity-browser-compiler@1.1.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FTech-Claw%2F_solidity-browser-compiler.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Tech-Claw/_solidity-browser-compiler/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Tech-Claw/_solidity-browser-compiler.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/Tech-Claw/_solidity-browser-compiler#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "units",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "80505eaaecd40e8d632b36a6b414965cfc0b258530b4ff005e2091cb84738e5f",
-      "author": "Richard Moore",
-      "description": "Unit conversion functions for Ethereum.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/units@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Funits",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/units",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "lodash-es",
-      "version": "4.17.23",
-      "bom-ref": "831f9821b0124146e8b1eb11e80d61f049f39d393a417f0d74415e1a6d3e6970",
-      "author": "John-David Dalton",
-      "description": "Lodash exported as ES modules.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/lodash-es@4.17.23?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Flodash%2Flodash.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/lodash/lodash-cli/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/lodash/lodash.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://lodash.com/custom-builds",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "animations",
       "group": "@angular",
       "version": "20.3.17",
-      "bom-ref": "87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
+      "bom-ref": "@angular/animations@20.3.17#87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
       "author": "angular",
       "description": "Angular - animations integration with web-animations",
       "scope": "required",
@@ -2993,12 +1334,11 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "strings",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-      "author": "Richard Moore",
-      "description": "String utility functions.",
+      "name": "cdk",
+      "group": "@angular",
+      "version": "20.2.14",
+      "bom-ref": "@angular/cdk@20.2.14#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+      "description": "Angular Material Component Development Kit",
       "scope": "required",
       "licenses": [
         {
@@ -3008,294 +1348,31 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/%40ethersproject/strings@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fstrings",
+      "purl": "pkg:npm/%40angular/cdk@20.2.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
       "externalReferences": [
         {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "url": "https://github.com/angular/components/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/strings",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.8.2",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.8.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
+          "url": "git+https://github.com/angular/components.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://rxjs.dev",
+          "url": "https://github.com/angular/components#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
-    },
-    {
-      "type": "library",
-      "name": "debug",
-      "version": "4.3.7",
-      "bom-ref": "97d4082d905bd7891eea5dcafbd82c9a89aa2617236cf546deca8231d3e82a58",
-      "author": "Josh Junon",
-      "description": "Lightweight debugging utility for Node.js and the browser",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/debug@4.3.7?vcs_url=git%3A%2F%2Fgithub.com%2Fdebug-js%2Fdebug.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/debug-js/debug/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/debug-js/debug.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/debug-js/debug#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "keccak256",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-      "author": "Richard Moore",
-      "description": "The keccak256 hash function for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/keccak256@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fkeccak256",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/keccak256",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "basex",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
-      "author": "Richard Moore",
-      "description": "Base-X without Buffer.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/basex@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbasex",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/basex",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "debug",
-      "version": "4.3.7",
-      "bom-ref": "9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487",
-      "author": "Josh Junon",
-      "description": "Lightweight debugging utility for Node.js and the browser",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/debug@4.3.7?vcs_url=git%3A%2F%2Fgithub.com%2Fdebug-js%2Fdebug.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/debug-js/debug/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/debug-js/debug.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/debug-js/debug#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "js-sha3",
-      "version": "0.8.0",
-      "bom-ref": "a19681ba3ff7a814b42c241beff8374c98b63794985df87ce6b75af891f67fc6",
-      "author": "Chen, Yi-Cyuan",
-      "description": "A simple SHA-3 / Keccak / Shake hash function for JavaScript supports UTF-8 encoding.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/js-sha3@0.8.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Femn178%2Fjs-sha3.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/emn178/js-sha3/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/emn178/js-sha3.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/emn178/js-sha3",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "dijkstrajs",
-      "version": "1.0.3",
-      "bom-ref": "a630b0274ebf498dd93ac568af1ea4352b0f7d942f74cb84eb8c1fda518a45b1",
-      "description": "A simple JavaScript implementation of Dijkstra's single-source shortest-paths algorithm.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/dijkstrajs@1.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ftcort%2Fdijkstrajs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/tcort/dijkstrajs/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/tcort/dijkstrajs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/tcort/dijkstrajs",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "core",
-      "group": "@ngx-translate",
-      "version": "15.0.0",
-      "bom-ref": "a7422bca70966a5c31971b49a4771d1dd160303eda80fbb06cdd7d4140d5bd48",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "name": "SEE LICENSE IN LICENSE",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ngx-translate/core@15.0.0"
     },
     {
       "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "20.3.17",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "scope": "required",
@@ -3328,536 +1405,10 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "router",
-      "group": "@angular",
-      "version": "20.3.17",
-      "bom-ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-      "author": "angular",
-      "description": "Angular - the routing library",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/router@20.3.17?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/router",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular/tree/main/packages/router",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "eventemitter3",
-      "version": "4.0.7",
-      "bom-ref": "a9fd1742886a43e2cfcf3eafb8d805733241afaa1ab4dc856406fce056ca0a23",
-      "author": "Arnout Kazemier",
-      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/eventemitter3@4.0.7?vcs_url=git%3A%2F%2Fgithub.com%2Fprimus%2Feventemitter3.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/primus/eventemitter3/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/primus/eventemitter3.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/primus/eventemitter3#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "backo2",
-      "version": "1.0.2",
-      "bom-ref": "aa5188dceffe08183a6d9a853dcefd9985f26040130ea31602286c6140b27556",
-      "description": "simple backoff based on segmentio/backo",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/backo2@1.0.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmokesmokes%2Fbacko.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/mokesmokes/backo/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/mokesmokes/backo.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/mokesmokes/backo#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "contracts",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "ac17ecc668ea148cef3ae5efafd0da41ee43e041354814546b344e76dd2064b2",
-      "author": "Richard Moore",
-      "description": "Contract abstraction meta-class for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/contracts@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fcontracts",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/contracts",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "flag-icons",
-      "version": "6.15.0",
-      "bom-ref": "ac8c40cfc6e68477fae3ea44ce291e60703c173fb49cc3f82f435c0c3fffb8b6",
-      "author": "Panayiotis Lipiridis",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/flag-icons@6.15.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Flipis%2Fflag-icons.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/lipis/flag-icons/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/lipis/flag-icons.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/lipis/flag-icons#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "hdnode",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
-      "author": "Richard Moore",
-      "description": "BIP32 Hierarchal Deterministic Node operations.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/hdnode@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fhdnode",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/hdnode",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ngx-text-diff",
-      "group": "@winarg",
-      "version": "19.0.1",
-      "bom-ref": "ae416b20d856a72845bd1d8a9a020de20852ea632cd9ecfb2f96f9276cfa6c4c",
-      "author": "Alfredo Benassi",
-      "description": "A Text Diff component for Angular.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40winarg/ngx-text-diff@19.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwinarg%2Fngx-text-diff.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/winarg/ngx-text-diff/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/winarg/ngx-text-diff.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/winarg/ngx-text-diff",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "aes-js",
-      "version": "3.0.0",
-      "bom-ref": "b074eb1e67f059f163b11978fc996cde910b48835d456d4b37e2c7479e50eee6",
-      "author": "Richard Moore",
-      "description": "A pure JavaScript implementation of the AES block cipher and all common modes of operation.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/aes-js@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fricmoo%2Faes-js.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/ricmoo/aes-js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ricmoo/aes-js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/ricmoo/aes-js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "free-solid-svg-icons",
-      "group": "@fortawesome",
-      "version": "5.15.4",
-      "bom-ref": "b27c1232e59e35a68d72eb621b561abc9d172ccb287f3e8db8d540922feeb403",
-      "author": "Dave Gandy",
-      "description": "The iconic font, CSS, and SVG framework",
-      "scope": "required",
-      "licenses": [
-        {
-          "expression": "(CC-BY-4.0 AND MIT)",
-          "acknowledgement": "declared"
-        }
-      ],
-      "purl": "pkg:npm/%40fortawesome/free-solid-svg-icons@5.15.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://fontawesome.com",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ngx-highlightjs",
-      "version": "14.0.1",
-      "bom-ref": "b3dfb133d42f90885db89be033e4dadda7fd7e388b712c72e8e84c8087144a5a",
-      "author": "Murhaf Sousli",
-      "description": "Instant code highlighting, auto-detect language, super easy to use.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ngx-highlightjs@14.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMurhafSousli%2Fngx-highlightjs.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/murhafsousli/ngx-highlightjs/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/MurhafSousli/ngx-highlightjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://ngx-highlight.netlify.app",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "core",
-      "group": "@wagmi",
-      "version": "0.5.8",
-      "bom-ref": "b3f01bcff85de93ebb785b67f734367ea3b74c9d14c3b78b3445a69620f7efbe",
-      "author": "awkweb.eth",
-      "description": "Vanilla JS library for Ethereum",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "name": "WAGMIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40wagmi/core@0.5.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwagmi-dev%2Fwagmi.git%23packages%2Fcore",
-      "externalReferences": [
-        {
-          "url": "https://github.com/wagmi-dev/wagmi/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/wagmi-dev/wagmi.git#packages/core",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/wagmi-dev/wagmi#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "scrypt-js",
-      "version": "3.0.1",
-      "bom-ref": "be31b7812813f6cafff435a2474c37b4ced000ac0a994bd4513e822451a3f2b0",
-      "author": "Richard Moore",
-      "description": "The scrypt password-based key derivation function with sync and cancellable async.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/scrypt-js@3.0.1?vcs_url=git%3A%2F%2Fgithub.com%2Fricmoo%2Fscrypt-js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ricmoo/scrypt-js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ricmoo/scrypt-js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/ricmoo/scrypt-js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "codemirror",
-      "version": "5.65.21",
-      "bom-ref": "c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3",
-      "author": "Marijn Haverbeke",
-      "description": "Full-featured in-browser code editor",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/codemirror@5.65.21?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcodemirror%2FCodeMirror.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/codemirror/CodeMirror/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/codemirror/CodeMirror.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://codemirror.net/5/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "snarkdown",
-      "version": "1.2.2",
-      "bom-ref": "ca565f4440a2bcd75007fbed65d41a7c4b6151bcf8a4d48c33024d085bf312ee",
-      "description": "Transform Markdown into HTML.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/snarkdown@1.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdevelopit%2Fsnarkdown.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/developit/snarkdown/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/developit/snarkdown.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/developit/snarkdown",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "tslib",
-      "version": "2.8.1",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "20.3.17",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "scope": "required",
@@ -3893,7 +1444,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
       "name": "forms",
       "group": "@angular",
       "version": "20.3.17",
-      "bom-ref": "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
+      "bom-ref": "@angular/forms@20.3.17#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
       "author": "angular",
       "description": "Angular - directives and services for creating forms",
       "scope": "required",
@@ -3926,222 +1477,11 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "ms",
-      "version": "2.1.3",
-      "bom-ref": "d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a",
-      "description": "Tiny millisecond conversion utility",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ms@2.1.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvercel%2Fms.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/vercel/ms/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/vercel/ms.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/vercel/ms#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "rlp",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
-      "author": "Richard Moore",
-      "description": "Recursive-Length Prefix (RLP) coder.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/rlp@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Frlp",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/rlp",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zustand",
-      "version": "4.5.7",
-      "bom-ref": "d579e4c38840ee6a708f796b6704861f3200d22c47c6d7d462eff784818c5aa0",
-      "author": "Paul Henschel",
-      "description": "🐻 Bear necessities for state management in React",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zustand@4.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fpmndrs%2Fzustand.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/pmndrs/zustand/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/pmndrs/zustand.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/pmndrs/zustand",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "free-regular-svg-icons",
-      "group": "@fortawesome",
-      "version": "5.15.4",
-      "bom-ref": "d5d8583bb1a5f97cd8d06f96692707d51a1b8fcfe49348ded1bfdd156d6ff43e",
-      "author": "Dave Gandy",
-      "description": "The iconic font, CSS, and SVG framework",
-      "scope": "required",
-      "licenses": [
-        {
-          "expression": "(CC-BY-4.0 AND MIT)",
-          "acknowledgement": "declared"
-        }
-      ],
-      "purl": "pkg:npm/%40fortawesome/free-regular-svg-icons@5.15.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
-      "externalReferences": [
-        {
-          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://fontawesome.com",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "web",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
-      "author": "Richard Moore",
-      "description": "Utility fucntions for managing web requests for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/web@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fweb",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/web",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "sha2",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
-      "author": "Richard Moore",
-      "description": "The SHA2 family hash functions and HMAC functions for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/sha2@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fsha2",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/sha2",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "cdk",
+      "name": "material",
       "group": "@angular",
       "version": "20.2.14",
-      "bom-ref": "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
-      "description": "Angular Material Component Development Kit",
+      "bom-ref": "@angular/material@20.2.14#2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
+      "description": "Angular Material",
       "scope": "required",
       "licenses": [
         {
@@ -4151,7 +1491,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/cdk@20.2.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
+      "purl": "pkg:npm/%40angular/material@20.2.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fcomponents.git",
       "externalReferences": [
         {
           "url": "https://github.com/angular/components/issues",
@@ -4172,10 +1512,12 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "socket.io-parser",
-      "version": "4.0.5",
-      "bom-ref": "e3886532e4f1634ce87c2148abd3b0ca4780fc5bee3e7e6b78cfb79bf8d5d9ad",
-      "description": "socket.io protocol parser",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "20.3.17",
+      "bom-ref": "@angular/platform-browser@20.3.17#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
       "scope": "required",
       "licenses": [
         {
@@ -4185,20 +1527,20 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/socket.io-parser@4.0.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsocketio%2Fsocket.io-parser.git",
+      "purl": "pkg:npm/%40angular/platform-browser@20.3.17?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
       "externalReferences": [
         {
-          "url": "https://github.com/socketio/socket.io-parser/issues",
+          "url": "https://github.com/angular/angular/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git+https://github.com/socketio/socket.io-parser.git",
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
           "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
         },
         {
-          "url": "https://github.com/socketio/socket.io-parser#readme",
+          "url": "https://github.com/angular/angular#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -4206,12 +1548,12 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "random",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
-      "author": "Richard Moore",
-      "description": "Random utility functions for ethers.",
+      "name": "router",
+      "group": "@angular",
+      "version": "20.3.17",
+      "bom-ref": "@angular/router@20.3.17#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "author": "angular",
+      "description": "Angular - the routing library",
       "scope": "required",
       "licenses": [
         {
@@ -4221,7 +1563,78 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/%40ethersproject/random@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Frandom",
+      "purl": "pkg:npm/%40angular/router@20.3.17?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/router",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular/tree/main/packages/router",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ngx-codemirror",
+      "group": "@ctrl",
+      "version": "7.0.0",
+      "bom-ref": "@ctrl/ngx-codemirror@7.0.0#54f3746bdae3b18da934798c490da1b34044aa8fd98714521bb76e38fd574568",
+      "description": "CodeMirror wrapper for Angular",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ctrl/ngx-codemirror@7.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fscttcper%2Fngx-codemirror.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/scttcper/ngx-codemirror/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/scttcper/ngx-codemirror.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/scttcper/ngx-codemirror",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "abi",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/abi@5.8.0#1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
+      "author": "Richard Moore",
+      "description": "Utilities and Classes for parsing, formatting and managing Ethereum ABIs.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/abi@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fabi",
       "externalReferences": [
         {
           "url": "https://github.com/ethers-io/ethers.js/issues",
@@ -4229,7 +1642,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/random",
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/abi",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
         },
@@ -4242,12 +1655,12 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "address",
+      "name": "abstract-provider",
       "group": "@ethersproject",
       "version": "5.8.0",
-      "bom-ref": "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+      "bom-ref": "@ethersproject/abstract-provider@5.8.0#292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
       "author": "Richard Moore",
-      "description": "Utilities for handling Ethereum Addresses for ethers.",
+      "description": "An Abstract Class for describing an Ethereum Provider for ethers.",
       "scope": "required",
       "licenses": [
         {
@@ -4257,7 +1670,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/%40ethersproject/address@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Faddress",
+      "purl": "pkg:npm/%40ethersproject/abstract-provider@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fabstract-provider",
       "externalReferences": [
         {
           "url": "https://github.com/ethers-io/ethers.js/issues",
@@ -4265,78 +1678,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/address",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/ethers-io/ethers.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "file-saver",
-      "version": "2.0.5",
-      "bom-ref": "e593fc3d170f3673dcde127c885b2cd6c3a5d4ff59eea51dc518bd6d9d1720f3",
-      "author": "Eli Grey",
-      "description": "An HTML5 saveAs() FileSaver implementation",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/file-saver@2.0.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Feligrey%2FFileSaver.js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/eligrey/FileSaver.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/eligrey/FileSaver.js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/eligrey/FileSaver.js#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "providers",
-      "group": "@ethersproject",
-      "version": "5.8.0",
-      "bom-ref": "e90ea37b7ba280946e6f55fc762d26f9122d8e6514b50b48a2d174f000526aaf",
-      "author": "Richard Moore",
-      "description": "Ethereum Providers for ethers.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40ethersproject/providers@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fproviders",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ethers-io/ethers.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/providers",
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/abstract-provider",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
         },
@@ -4352,7 +1694,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
       "name": "abstract-signer",
       "group": "@ethersproject",
       "version": "5.8.0",
-      "bom-ref": "ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
+      "bom-ref": "@ethersproject/abstract-signer@5.8.0#ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
       "author": "Richard Moore",
       "description": "An Abstract Class for desribing an Ethereum Signer for ethers.",
       "scope": "required",
@@ -4385,47 +1727,12 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "highlight.js",
-      "version": "11.11.1",
-      "bom-ref": "f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18",
-      "author": "Josh Goebel",
-      "description": "Syntax highlighting with language autodetection.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/highlight.js@11.11.1?vcs_url=git%3A%2F%2Fgithub.com%2Fhighlightjs%2Fhighlight.js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/highlightjs/highlight.js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/highlightjs/highlight.js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://highlightjs.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "networks",
+      "name": "address",
       "group": "@ethersproject",
       "version": "5.8.0",
-      "bom-ref": "f35ac392b09cf8b99413fc9bfe79c72437a652572314886cc09b0d397308ede7",
+      "bom-ref": "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
       "author": "Richard Moore",
-      "description": "Network definitions for ethers.",
+      "description": "Utilities for handling Ethereum Addresses for ethers.",
       "scope": "required",
       "licenses": [
         {
@@ -4435,7 +1742,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/%40ethersproject/networks@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fnetworks",
+      "purl": "pkg:npm/%40ethersproject/address@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Faddress",
       "externalReferences": [
         {
           "url": "https://github.com/ethers-io/ethers.js/issues",
@@ -4443,7 +1750,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/networks",
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/address",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
         },
@@ -4456,12 +1763,12 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "wallet",
+      "name": "base64",
       "group": "@ethersproject",
       "version": "5.8.0",
-      "bom-ref": "f3c01e9a7345dc4da30b88a2bbd076139b38d105e88dfe9e22984964eca03c59",
+      "bom-ref": "@ethersproject/base64@5.8.0#393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
       "author": "Richard Moore",
-      "description": "Classes for managing, encrypting and decrypting Ethereum private keys as a Signer for ethers.",
+      "description": "Base64 coder.",
       "scope": "required",
       "licenses": [
         {
@@ -4471,7 +1778,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/%40ethersproject/wallet@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fwallet",
+      "purl": "pkg:npm/%40ethersproject/base64@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbase64",
       "externalReferences": [
         {
           "url": "https://github.com/ethers-io/ethers.js/issues",
@@ -4479,7 +1786,115 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/ethers-io/ethers.js.git#packages/wallet",
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/base64",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "basex",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/basex@5.8.0#9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
+      "author": "Richard Moore",
+      "description": "Base-X without Buffer.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/basex@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbasex",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/basex",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "bignumber",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+      "author": "Richard Moore",
+      "description": "BigNumber library used in ethers.js.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/bignumber@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbignumber",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/bignumber",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "bytes",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+      "author": "Richard Moore",
+      "description": "Bytes utility functions for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/bytes@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fbytes",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/bytes",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
         },
@@ -4495,7 +1910,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
       "name": "constants",
       "group": "@ethersproject",
       "version": "5.8.0",
-      "bom-ref": "f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
+      "bom-ref": "@ethersproject/constants@5.8.0#f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
       "author": "Richard Moore",
       "description": "Common Ethereum constants used for ethers.",
       "scope": "required",
@@ -4528,9 +1943,2212 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
+      "name": "contracts",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/contracts@5.8.0#ac17ecc668ea148cef3ae5efafd0da41ee43e041354814546b344e76dd2064b2",
+      "author": "Richard Moore",
+      "description": "Contract abstraction meta-class for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/contracts@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fcontracts",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/contracts",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "hash",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/hash@5.8.0#2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
+      "author": "Richard Moore",
+      "description": "Hash utility functions for Ethereum.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/hash@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fhash",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/hash",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "hdnode",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/hdnode@5.8.0#ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
+      "author": "Richard Moore",
+      "description": "BIP32 Hierarchal Deterministic Node operations.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/hdnode@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fhdnode",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/hdnode",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "json-wallets",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/json-wallets@5.8.0#4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
+      "author": "Richard Moore",
+      "description": "Wallet management utilities for KeyStore and Crowdsale JSON wallets.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/json-wallets@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fjson-wallets",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/json-wallets",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "keccak256",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+      "author": "Richard Moore",
+      "description": "The keccak256 hash function for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/keccak256@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fkeccak256",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/keccak256",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "logger",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+      "author": "Richard Moore",
+      "description": "Logger utility functions for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/logger@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Flogger",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/logger",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "networks",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/networks@5.8.0#f35ac392b09cf8b99413fc9bfe79c72437a652572314886cc09b0d397308ede7",
+      "author": "Richard Moore",
+      "description": "Network definitions for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/networks@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fnetworks",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/networks",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "pbkdf2",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/pbkdf2@5.8.0#28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
+      "author": "Richard Moore",
+      "description": "The PBKDF2 password-pbased key derivation function for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/pbkdf2@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fpbkdf2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/pbkdf2",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "properties",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+      "author": "Richard Moore",
+      "description": "Properties utility functions for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/properties@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fproperties",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/properties",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "providers",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/providers@5.8.0#e90ea37b7ba280946e6f55fc762d26f9122d8e6514b50b48a2d174f000526aaf",
+      "author": "Richard Moore",
+      "description": "Ethereum Providers for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/providers@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fproviders",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/providers",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "random",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/random@5.8.0#e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
+      "author": "Richard Moore",
+      "description": "Random utility functions for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/random@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Frandom",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/random",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "rlp",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/rlp@5.8.0#d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
+      "author": "Richard Moore",
+      "description": "Recursive-Length Prefix (RLP) coder.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/rlp@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Frlp",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/rlp",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "sha2",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/sha2@5.8.0#de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
+      "author": "Richard Moore",
+      "description": "The SHA2 family hash functions and HMAC functions for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/sha2@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fsha2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/sha2",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "signing-key",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/signing-key@5.8.0#5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
+      "author": "Richard Moore",
+      "description": "Elliptic curve library functions for the secp256k1 curve.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/signing-key@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fsigning-key",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/signing-key",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "solidity",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/solidity@5.8.0#5536aef1348089387c04172edddfa56e2ae144f384aa4871c035ab0d94621a47",
+      "author": "Richard Moore",
+      "description": "Solidity coder for non-standard (tight) packing.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/solidity@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fsolidity",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/solidity",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "strings",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
+      "author": "Richard Moore",
+      "description": "String utility functions.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/strings@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fstrings",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/strings",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "transactions",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
+      "author": "Richard Moore",
+      "description": "Utilities for decoding and encoding Ethereum transaction for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/transactions@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Ftransactions",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/transactions",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "units",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/units@5.8.0#80505eaaecd40e8d632b36a6b414965cfc0b258530b4ff005e2091cb84738e5f",
+      "author": "Richard Moore",
+      "description": "Unit conversion functions for Ethereum.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/units@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Funits",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/units",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "wallet",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/wallet@5.8.0#f3c01e9a7345dc4da30b88a2bbd076139b38d105e88dfe9e22984964eca03c59",
+      "author": "Richard Moore",
+      "description": "Classes for managing, encrypting and decrypting Ethereum private keys as a Signer for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/wallet@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fwallet",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/wallet",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "web",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/web@5.8.0#d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
+      "author": "Richard Moore",
+      "description": "Utility fucntions for managing web requests for ethers.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/web@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fweb",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/web",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "wordlists",
+      "group": "@ethersproject",
+      "version": "5.8.0",
+      "bom-ref": "@ethersproject/wordlists@5.8.0#5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6",
+      "author": "Richard Moore",
+      "description": "Word lists for BIP39 wallets.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ethersproject/wordlists@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fwordlists",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/wordlists",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "fontawesome-svg-core",
+      "group": "@fortawesome",
+      "version": "1.2.36",
+      "bom-ref": "@fortawesome/fontawesome-svg-core@1.2.36#3e0945a272ea197886256c13e5d9d01ea14c18e8a345d0b5a14c524d3c316053",
+      "author": "Dave Gandy",
+      "description": "The iconic font, CSS, and SVG framework",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40fortawesome/fontawesome-svg-core@1.2.36?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://fontawesome.com",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "free-brands-svg-icons",
+      "group": "@fortawesome",
+      "version": "5.15.4",
+      "bom-ref": "@fortawesome/free-brands-svg-icons@5.15.4#23aeadff4c49ed6fe259ceedace718a1b3a87758bb84f447a7233d6ef697b01a",
+      "author": "Dave Gandy",
+      "description": "The iconic font, CSS, and SVG framework",
+      "scope": "required",
+      "licenses": [
+        {
+          "expression": "(CC-BY-4.0 AND MIT)",
+          "acknowledgement": "declared"
+        }
+      ],
+      "purl": "pkg:npm/%40fortawesome/free-brands-svg-icons@5.15.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://fontawesome.com",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "free-regular-svg-icons",
+      "group": "@fortawesome",
+      "version": "5.15.4",
+      "bom-ref": "@fortawesome/free-regular-svg-icons@5.15.4#d5d8583bb1a5f97cd8d06f96692707d51a1b8fcfe49348ded1bfdd156d6ff43e",
+      "author": "Dave Gandy",
+      "description": "The iconic font, CSS, and SVG framework",
+      "scope": "required",
+      "licenses": [
+        {
+          "expression": "(CC-BY-4.0 AND MIT)",
+          "acknowledgement": "declared"
+        }
+      ],
+      "purl": "pkg:npm/%40fortawesome/free-regular-svg-icons@5.15.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://fontawesome.com",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "free-solid-svg-icons",
+      "group": "@fortawesome",
+      "version": "5.15.4",
+      "bom-ref": "@fortawesome/free-solid-svg-icons@5.15.4#b27c1232e59e35a68d72eb621b561abc9d172ccb287f3e8db8d540922feeb403",
+      "author": "Dave Gandy",
+      "description": "The iconic font, CSS, and SVG framework",
+      "scope": "required",
+      "licenses": [
+        {
+          "expression": "(CC-BY-4.0 AND MIT)",
+          "acknowledgement": "declared"
+        }
+      ],
+      "purl": "pkg:npm/%40fortawesome/free-solid-svg-icons@5.15.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FFortAwesome%2FFont-Awesome.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/FortAwesome/Font-Awesome/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/FortAwesome/Font-Awesome.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://fontawesome.com",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "core",
+      "group": "@ngx-translate",
+      "version": "15.0.0",
+      "bom-ref": "@ngx-translate/core@15.0.0#a7422bca70966a5c31971b49a4771d1dd160303eda80fbb06cdd7d4140d5bd48",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "name": "SEE LICENSE IN LICENSE",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ngx-translate/core@15.0.0"
+    },
+    {
+      "type": "library",
+      "name": "http-loader",
+      "group": "@ngx-translate",
+      "version": "8.0.0",
+      "bom-ref": "@ngx-translate/http-loader@8.0.0#696641cb855cdee93723c8240382c89a8306a582d3991f0477fc57308d2d8014",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "name": "SEE LICENSE IN LICENSE",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40ngx-translate/http-loader@8.0.0"
+    },
+    {
+      "type": "library",
+      "name": "core",
+      "group": "@wagmi",
+      "version": "0.5.8",
+      "bom-ref": "@wagmi/core@0.5.8#b3f01bcff85de93ebb785b67f734367ea3b74c9d14c3b78b3445a69620f7efbe",
+      "author": "awkweb.eth",
+      "description": "Vanilla JS library for Ethereum",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "name": "WAGMIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wagmi/core@0.5.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwagmi-dev%2Fwagmi.git%23packages%2Fcore",
+      "externalReferences": [
+        {
+          "url": "https://github.com/wagmi-dev/wagmi/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/wagmi-dev/wagmi.git#packages/core",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/wagmi-dev/wagmi#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ngx-text-diff",
+      "group": "@winarg",
+      "version": "19.0.1",
+      "bom-ref": "@winarg/ngx-text-diff@19.0.1#ae416b20d856a72845bd1d8a9a020de20852ea632cd9ecfb2f96f9276cfa6c4c",
+      "author": "Alfredo Benassi",
+      "description": "A Text Diff component for Angular.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40winarg/ngx-text-diff@19.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwinarg%2Fngx-text-diff.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/winarg/ngx-text-diff/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/winarg/ngx-text-diff.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/winarg/ngx-text-diff",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "aes-js",
+      "version": "3.0.0",
+      "bom-ref": "aes-js@3.0.0#b074eb1e67f059f163b11978fc996cde910b48835d456d4b37e2c7479e50eee6",
+      "author": "Richard Moore",
+      "description": "A pure JavaScript implementation of the AES block cipher and all common modes of operation.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/aes-js@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fricmoo%2Faes-js.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/ricmoo/aes-js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ricmoo/aes-js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/ricmoo/aes-js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "backo2",
+      "version": "1.0.2",
+      "bom-ref": "backo2@1.0.2#aa5188dceffe08183a6d9a853dcefd9985f26040130ea31602286c6140b27556",
+      "description": "simple backoff based on segmentio/backo",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/backo2@1.0.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmokesmokes%2Fbacko.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mokesmokes/backo/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/mokesmokes/backo.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/mokesmokes/backo#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "base64-arraybuffer",
+      "version": "0.1.4",
+      "bom-ref": "base64-arraybuffer@0.1.4#668fbe027e327ad3dae761769c6811220166b2e4087fcd0731a4599b571774f4",
+      "author": "Niklas von Hertzen",
+      "description": "Encode/decode base64 data into ArrayBuffers",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared",
+            "url": "https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/base64-arraybuffer@0.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fniklasvh%2Fbase64-arraybuffer.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/niklasvh/base64-arraybuffer/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/niklasvh/base64-arraybuffer.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/niklasvh/base64-arraybuffer",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "bech32",
+      "version": "1.1.4",
+      "bom-ref": "bech32@1.1.4#58e67da2ac79d3a7fb5463e0e89caa3346e3879ca25c384fc9a58b950e81cea0",
+      "description": "Bech32 encoding / decoding",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/bech32@1.1.4?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fbitcoinjs%2Fbech32.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/bitcoinjs/bech32/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+ssh://git@github.com/bitcoinjs/bech32.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/bitcoinjs/bech32#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "bn.js",
+      "version": "5.2.3",
+      "bom-ref": "bn.js@5.2.3#3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1",
+      "author": "Fedor Indutny",
+      "description": "Big number implementation in pure javascript",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/bn.js@5.2.3?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Findutny%2Fbn.js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/indutny/bn.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+ssh://git@github.com/indutny/bn.js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/indutny/bn.js",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "canvas-confetti",
+      "version": "1.9.4",
+      "bom-ref": "canvas-confetti@1.9.4#470080acde1191c2f60340adb57cf459ed26b92c63755bf042f1cbb73fd164d6",
+      "author": "Kiril Vatev",
+      "description": "performant confetti animation in the browser",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/canvas-confetti@1.9.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcatdad%2Fcanvas-confetti.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/catdad/canvas-confetti/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/catdad/canvas-confetti.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/catdad/canvas-confetti#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "codemirror-solidity",
+      "version": "0.2.5",
+      "bom-ref": "codemirror-solidity@0.2.5#1387fa0e934f50384db142905d7f5c576ad88b3fbf172362ba3b14ee03a6a6f1",
+      "author": "alincode",
+      "description": "codemirror solidity mode",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/codemirror-solidity@0.2.5",
+      "externalReferences": [
+        {
+          "url": "https://github.com/alincode/codemirror-solidity#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "codemirror",
+      "version": "5.65.21",
+      "bom-ref": "codemirror@5.65.21#c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3",
+      "author": "Marijn Haverbeke",
+      "description": "Full-featured in-browser code editor",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/codemirror@5.65.21?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcodemirror%2FCodeMirror.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/codemirror/CodeMirror/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/codemirror/CodeMirror.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://codemirror.net/5/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "component-emitter",
+      "version": "1.3.1",
+      "bom-ref": "component-emitter@1.3.1#0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
+      "description": "Event emitter",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/component-emitter@1.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsindresorhus%2Fcomponent-emitter.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/sindresorhus/component-emitter/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/sindresorhus/component-emitter.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/sindresorhus/component-emitter#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "cookieconsent",
+      "version": "3.1.1",
+      "bom-ref": "cookieconsent@3.1.1#70465b851954084600d4d20d0e95204b6741f5a109d78a6f967612fb72974d70",
+      "author": "Osano, Inc., a Public Benefit Corporation",
+      "description": "Osano cookie consent tool.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/cookieconsent@3.1.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fosano%2Fcookieconsent.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/osano/cookieconsent/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/osano/cookieconsent.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "http://cookieconsent.osano.com/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "debug",
+      "version": "4.3.7",
+      "bom-ref": "debug@4.3.7#97d4082d905bd7891eea5dcafbd82c9a89aa2617236cf546deca8231d3e82a58",
+      "author": "Josh Junon",
+      "description": "Lightweight debugging utility for Node.js and the browser",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/debug@4.3.7?vcs_url=git%3A%2F%2Fgithub.com%2Fdebug-js%2Fdebug.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/debug-js/debug/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/debug-js/debug.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/debug-js/debug#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "debug",
+      "version": "4.3.7",
+      "bom-ref": "debug@4.3.7#9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487",
+      "author": "Josh Junon",
+      "description": "Lightweight debugging utility for Node.js and the browser",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/debug@4.3.7?vcs_url=git%3A%2F%2Fgithub.com%2Fdebug-js%2Fdebug.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/debug-js/debug/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/debug-js/debug.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/debug-js/debug#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "diff-match-patch",
+      "version": "1.0.5",
+      "bom-ref": "diff-match-patch@1.0.5#707c94303cf21f2f18fbd2e689f593e0dd2dbeb2cfb65df8e62abc3917f3afd3",
+      "description": "npm package for https://github.com/google/diff-match-patch",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/diff-match-patch@1.0.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FJackuB%2Fdiff-match-patch.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/JackuB/diff-match-patch/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/JackuB/diff-match-patch.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/JackuB/diff-match-patch#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "dijkstrajs",
+      "version": "1.0.3",
+      "bom-ref": "dijkstrajs@1.0.3#a630b0274ebf498dd93ac568af1ea4352b0f7d942f74cb84eb8c1fda518a45b1",
+      "description": "A simple JavaScript implementation of Dijkstra's single-source shortest-paths algorithm.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/dijkstrajs@1.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ftcort%2Fdijkstrajs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/tcort/dijkstrajs/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/tcort/dijkstrajs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/tcort/dijkstrajs",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "engine.io-client",
+      "version": "4.1.4",
+      "bom-ref": "engine.io-client@4.1.4#fd1fc69cef6438a9e0f179bdf175b6f5c86e3e71c06e8d8b1f484b5507627f72",
+      "description": "Client for the realtime Engine",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/engine.io-client@4.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsocketio%2Fengine.io-client.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/socketio/engine.io-client/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/socketio/engine.io-client.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/socketio/engine.io-client",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "engine.io-parser",
+      "version": "4.0.3",
+      "bom-ref": "engine.io-parser@4.0.3#49646800769b71f6867412afd9659b95d3915a506b240b81ed1f154f01ba25cb",
+      "description": "Parser for the client for the realtime Engine",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/engine.io-parser@4.0.3?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fsocketio%2Fengine.io-parser.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/socketio/engine.io-parser/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+ssh://git@github.com/socketio/engine.io-parser.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/socketio/engine.io-parser",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ethers",
+      "version": "5.8.0",
+      "bom-ref": "ethers@5.8.0#2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
+      "author": "Richard Moore",
+      "description": "Umbrella package for most common Ethers libraries.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ethers@5.8.0?vcs_url=git%3A%2F%2Fgithub.com%2Fethers-io%2Fethers.js.git%23packages%2Fethers",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ethers-io/ethers.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ethers-io/ethers.js.git#packages/ethers",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/ethers-io/ethers.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "eventemitter3",
+      "version": "4.0.7",
+      "bom-ref": "eventemitter3@4.0.7#a9fd1742886a43e2cfcf3eafb8d805733241afaa1ab4dc856406fce056ca0a23",
+      "author": "Arnout Kazemier",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/eventemitter3@4.0.7?vcs_url=git%3A%2F%2Fgithub.com%2Fprimus%2Feventemitter3.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/primus/eventemitter3/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/primus/eventemitter3.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/primus/eventemitter3#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "file-saver",
+      "version": "2.0.5",
+      "bom-ref": "file-saver@2.0.5#e593fc3d170f3673dcde127c885b2cd6c3a5d4ff59eea51dc518bd6d9d1720f3",
+      "author": "Eli Grey",
+      "description": "An HTML5 saveAs() FileSaver implementation",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/file-saver@2.0.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Feligrey%2FFileSaver.js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/eligrey/FileSaver.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/eligrey/FileSaver.js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/eligrey/FileSaver.js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "flag-icons",
+      "version": "6.15.0",
+      "bom-ref": "flag-icons@6.15.0#ac8c40cfc6e68477fae3ea44ce291e60703c173fb49cc3f82f435c0c3fffb8b6",
+      "author": "Panayiotis Lipiridis",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/flag-icons@6.15.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Flipis%2Fflag-icons.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/lipis/flag-icons/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/lipis/flag-icons.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/lipis/flag-icons#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "font-mfizz",
+      "version": "2.4.1",
+      "bom-ref": "font-mfizz@2.4.1#6a0d1d6f94e6c564ed811d8e12383096c32bc5be56ee8ec1348cc932765b57a5",
+      "author": "Fizzed, Inc.",
+      "description": "Font Mfizz - Vector Icons for Technology and Software Geeks ===========================================================",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/font-mfizz@2.4.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffizzed%2Ffont-mfizz.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/fizzed/font-mfizz/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/fizzed/font-mfizz.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "http://fizzed.com/oss/font-mfizz",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "has-cors",
+      "version": "1.1.0",
+      "bom-ref": "has-cors@1.1.0#4463ae507d574f1c1e49f9e4523d3e45d2fb18df2ff83b1153c23aca4862db35",
+      "author": "Nathan Rajlich",
+      "description": "Detects support for Cross-Origin Resource Sharing",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/has-cors@1.1.0?vcs_url=git%3A%2F%2Fgithub.com%2Fcomponent%2Fhas-cors.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/component/has-cors/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/component/has-cors.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/component/has-cors#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "hash.js",
+      "version": "1.1.7",
+      "bom-ref": "hash.js@1.1.7#419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91",
+      "author": "Fedor Indutny",
+      "description": "Various hash functions that could be run by both browser and node",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/hash.js@1.1.7?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Findutny%2Fhash.js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/indutny/hash.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+ssh://git@github.com/indutny/hash.js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/indutny/hash.js",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "highlight.js",
+      "version": "11.11.1",
+      "bom-ref": "highlight.js@11.11.1#f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18",
+      "author": "Josh Goebel",
+      "description": "Syntax highlighting with language autodetection.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/highlight.js@11.11.1?vcs_url=git%3A%2F%2Fgithub.com%2Fhighlightjs%2Fhighlight.js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/highlightjs/highlight.js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/highlightjs/highlight.js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://highlightjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "inherits",
+      "version": "2.0.4",
+      "bom-ref": "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+      "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/isaacs/inherits/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/isaacs/inherits.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/isaacs/inherits#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "js-sha3",
+      "version": "0.8.0",
+      "bom-ref": "js-sha3@0.8.0#a19681ba3ff7a814b42c241beff8374c98b63794985df87ce6b75af891f67fc6",
+      "author": "Chen, Yi-Cyuan",
+      "description": "A simple SHA-3 / Keccak / Shake hash function for JavaScript supports UTF-8 encoding.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/js-sha3@0.8.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Femn178%2Fjs-sha3.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emn178/js-sha3/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/emn178/js-sha3.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/emn178/js-sha3",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "jwt-decode",
+      "version": "2.2.0",
+      "bom-ref": "jwt-decode@2.2.0#fe9db2c2dcba6794c74deb46be575c01825056eda6a775af76e34f04db16f42a",
+      "author": "Jose F. Romaniello",
+      "description": "Decode JWT tokens, mostly useful for browser applications.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/jwt-decode@2.2.0?vcs_url=git%3A%2F%2Fgithub.com%2Fauth0%2Fjwt-decode.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/auth0/jwt-decode/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/auth0/jwt-decode.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/auth0/jwt-decode#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "lodash-es",
+      "version": "4.17.23",
+      "bom-ref": "lodash-es@4.17.23#831f9821b0124146e8b1eb11e80d61f049f39d393a417f0d74415e1a6d3e6970",
+      "author": "John-David Dalton",
+      "description": "Lodash exported as ES modules.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/lodash-es@4.17.23?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Flodash%2Flodash.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/lodash/lodash-cli/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/lodash/lodash.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://lodash.com/custom-builds",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "material-icons",
+      "version": "0.3.1",
+      "bom-ref": "material-icons@0.3.1#71cfcf50345fafd2898e8bf30ca83b02511aed3de0296baec389acb50b5798cc",
+      "description": "Material design icon font and CSS framework for self hosting the icons.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/material-icons@0.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmarella%2Fmaterial-icons.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/marella/material-icons/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/marella/material-icons.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://marella.github.io/material-icons/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "minimalistic-assert",
+      "version": "1.0.1",
+      "bom-ref": "minimalistic-assert@1.0.1#1dcf4229ac09993c5669a6bbbd2a2c7781e5cddc8c05791b8007747707c4796d",
+      "description": "minimalistic-assert ===",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/minimalistic-assert@1.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcalvinmetcalf%2Fminimalistic-assert.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/calvinmetcalf/minimalistic-assert/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/calvinmetcalf/minimalistic-assert.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/calvinmetcalf/minimalistic-assert",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ms",
+      "version": "2.1.3",
+      "bom-ref": "ms@2.1.3#d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a",
+      "description": "Tiny millisecond conversion utility",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ms@2.1.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvercel%2Fms.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/vercel/ms/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/vercel/ms.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/vercel/ms#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ng-gallery",
+      "version": "12.0.0",
+      "bom-ref": "ng-gallery@12.0.0#5e91ea783d620d2fd4ea7a5ec9e85d4c8c194e2f9c758a2a47893e4d100b9372",
+      "author": "Murhaf Sousli",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ng-gallery@12.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fmurhafsousli%2Fngx-gallery.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/murhafsousli/ngx-gallery/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/murhafsousli/ngx-gallery.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://ngx-gallery.netlify.app/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ng-qrcode",
+      "version": "20.0.1",
+      "bom-ref": "ng-qrcode@20.0.1#5ee3fef5d3e4bd3b22d71ad1e6126d725035e7ad5f4f4c977309af050e7ed6f8",
+      "author": "Michael Nahkies",
+      "description": "Simple AOT compatible QR code generator for your Angular project.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ng-qrcode@20.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmnahkies%2Fng-qrcode.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mnahkies/ng-qrcode/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/mnahkies/ng-qrcode.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/mnahkies/ng-qrcode#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ng2-file-upload",
+      "version": "9.0.0",
+      "bom-ref": "ng2-file-upload@9.0.0#061ec3972fcd2bf843e949590c0c995be1d6d66f794edcc68d526957eb76d864",
+      "author": "Dmitriy Shekhovtsov",
+      "description": "Angular file uploader",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ng2-file-upload@9.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fvalor-software%2Fng2-file-upload.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/valor-software/ng2-file-upload/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+ssh://git@github.com/valor-software/ng2-file-upload.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/valor-software/ng2-file-upload#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ngx-highlightjs",
+      "version": "14.0.1",
+      "bom-ref": "ngx-highlightjs@14.0.1#b3dfb133d42f90885db89be033e4dadda7fd7e388b712c72e8e84c8087144a5a",
+      "author": "Murhaf Sousli",
+      "description": "Instant code highlighting, auto-detect language, super easy to use.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ngx-highlightjs@14.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMurhafSousli%2Fngx-highlightjs.git",
+      "externalReferences": [
+        {
+          "url": "http://github.com/murhafsousli/ngx-highlightjs/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/MurhafSousli/ngx-highlightjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://ngx-highlight.netlify.app",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "ngy-cookie",
       "version": "6.0.1000",
-      "bom-ref": "f6c6d90a2f0fb70d0075b453208211ba2e79e559398d84ccbde8713427091759",
+      "bom-ref": "ngy-cookie@6.0.1000#f6c6d90a2f0fb70d0075b453208211ba2e79e559398d84ccbde8713427091759",
       "author": "Samet Alemdar",
       "description": "Implementation of Angular 1.x $cookies service to Angular",
       "scope": "required",
@@ -4563,10 +4181,11 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "engine.io-client",
-      "version": "4.1.4",
-      "bom-ref": "fd1fc69cef6438a9e0f179bdf175b6f5c86e3e71c06e8d8b1f484b5507627f72",
-      "description": "Client for the realtime Engine",
+      "name": "parseqs",
+      "version": "0.0.6",
+      "bom-ref": "parseqs@0.0.6#7c49e48d5f65924f5e8731ac61343484eacef2248600f5050c75e4737fde12eb",
+      "author": "Gal Koren",
+      "description": "Provides methods for parsing a query string into an object, and vice versa.",
       "scope": "required",
       "licenses": [
         {
@@ -4576,20 +4195,20 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/engine.io-client@4.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsocketio%2Fengine.io-client.git",
+      "purl": "pkg:npm/parseqs@0.0.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fget%2Fquerystring.git",
       "externalReferences": [
         {
-          "url": "https://github.com/socketio/engine.io-client/issues",
+          "url": "https://github.com/get/querystring/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git+https://github.com/socketio/engine.io-client.git",
+          "url": "git+https://github.com/get/querystring.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/socketio/engine.io-client",
+          "url": "https://github.com/get/querystring",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -4597,11 +4216,11 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     },
     {
       "type": "library",
-      "name": "jwt-decode",
-      "version": "2.2.0",
-      "bom-ref": "fe9db2c2dcba6794c74deb46be575c01825056eda6a775af76e34f04db16f42a",
-      "author": "Jose F. Romaniello",
-      "description": "Decode JWT tokens, mostly useful for browser applications.",
+      "name": "parseuri",
+      "version": "0.0.6",
+      "bom-ref": "parseuri@0.0.6#11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f",
+      "author": "Gal Koren",
+      "description": "Method that parses a URI and returns an array of its components",
       "scope": "required",
       "licenses": [
         {
@@ -4611,20 +4230,401 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
           }
         }
       ],
-      "purl": "pkg:npm/jwt-decode@2.2.0?vcs_url=git%3A%2F%2Fgithub.com%2Fauth0%2Fjwt-decode.git",
+      "purl": "pkg:npm/parseuri@0.0.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fget%2Fparseuri.git",
       "externalReferences": [
         {
-          "url": "https://github.com/auth0/jwt-decode/issues",
+          "url": "https://github.com/get/parseuri/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/auth0/jwt-decode.git",
+          "url": "git+https://github.com/get/parseuri.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/auth0/jwt-decode#readme",
+          "url": "https://github.com/get/parseuri",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "qrcode",
+      "version": "1.5.4",
+      "bom-ref": "qrcode@1.5.4#593e2111acde3c2317ba496deb365ec7f1c6b3a8783dd53ed9572947c1a19079",
+      "author": "Ryan Day",
+      "description": "QRCode / 2d Barcode api with both server side and client side support using canvas",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/qrcode@1.5.4?vcs_url=git%3A%2F%2Fgithub.com%2Fsoldair%2Fnode-qrcode.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/soldair/node-qrcode/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/soldair/node-qrcode.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "http://github.com/soldair/node-qrcode",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.8.2",
+      "bom-ref": "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.8.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "scrypt-js",
+      "version": "3.0.1",
+      "bom-ref": "scrypt-js@3.0.1#be31b7812813f6cafff435a2474c37b4ced000ac0a994bd4513e822451a3f2b0",
+      "author": "Richard Moore",
+      "description": "The scrypt password-based key derivation function with sync and cancellable async.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/scrypt-js@3.0.1?vcs_url=git%3A%2F%2Fgithub.com%2Fricmoo%2Fscrypt-js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ricmoo/scrypt-js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/ricmoo/scrypt-js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/ricmoo/scrypt-js#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "snarkdown",
+      "version": "1.2.2",
+      "bom-ref": "snarkdown@1.2.2#ca565f4440a2bcd75007fbed65d41a7c4b6151bcf8a4d48c33024d085bf312ee",
+      "description": "Transform Markdown into HTML.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/snarkdown@1.2.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdevelopit%2Fsnarkdown.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/developit/snarkdown/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/developit/snarkdown.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/developit/snarkdown",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "socket.io-client",
+      "version": "3.1.3",
+      "bom-ref": "socket.io-client@3.1.3#782d1c52d92feccc4f974775dbac70403aee3f7762a947388268d2ca320c30c8",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/socket.io-client@3.1.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsocketio%2Fsocket.io-client.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/socketio/socket.io-client/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/socketio/socket.io-client.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/socketio/socket.io-client#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "socket.io-parser",
+      "version": "4.0.5",
+      "bom-ref": "socket.io-parser@4.0.5#e3886532e4f1634ce87c2148abd3b0ca4780fc5bee3e7e6b78cfb79bf8d5d9ad",
+      "description": "socket.io protocol parser",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/socket.io-parser@4.0.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fsocketio%2Fsocket.io-parser.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/socketio/socket.io-parser/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/socketio/socket.io-parser.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/socketio/socket.io-parser#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "solidity-browser-compiler",
+      "version": "1.1.0",
+      "bom-ref": "solidity-browser-compiler@1.1.0#7f785beb037a50a59c946f3bb834293e69ab22dbb1682a86fa0528a6c4f2c790",
+      "author": "Nikola Bozin",
+      "description": "Package for compiling solidity code in the browser.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/solidity-browser-compiler@1.1.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FTech-Claw%2F_solidity-browser-compiler.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Tech-Claw/_solidity-browser-compiler/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Tech-Claw/_solidity-browser-compiler.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/Tech-Claw/_solidity-browser-compiler#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.8.1",
+      "bom-ref": "tslib@2.8.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "yeast",
+      "version": "0.1.2",
+      "bom-ref": "yeast@0.1.2#460939b68f8053fe278cb6210f7b2d9187940178fca9abf270d11ff80bda5aa0",
+      "author": "Arnout Kazemier",
+      "description": "Tiny but linear growing unique id generator",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/yeast@0.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Funshiftio%2Fyeast.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/unshiftio/yeast/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/unshiftio/yeast.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/unshiftio/yeast",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.15.1",
+      "bom-ref": "zone.js@0.15.1#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.15.1?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zustand",
+      "version": "4.5.7",
+      "bom-ref": "zustand@4.5.7#d579e4c38840ee6a708f796b6704861f3200d22c47c6d7d462eff784818c5aa0",
+      "author": "Paul Henschel",
+      "description": "🐻 Bear necessities for state management in React",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zustand@4.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fpmndrs%2Fzustand.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/pmndrs/zustand/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/pmndrs/zustand.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/pmndrs/zustand",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -11809,479 +11809,560 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
   ],
   "dependencies": [
     {
-      "ref": "061ec3972fcd2bf843e949590c0c995be1d6d66f794edcc68d526957eb76d864",
+      "ref": "@angular/animations@20.3.17#87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c"
-    },
-    {
-      "ref": "11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f"
-    },
-    {
-      "ref": "1387fa0e934f50384db142905d7f5c576ad88b3fbf172362ba3b14ee03a6a6f1"
-    },
-    {
-      "ref": "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+      "ref": "@angular/cdk@20.2.14#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
       "dependsOn": [
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "1dcf4229ac09993c5669a6bbbd2a2c7781e5cddc8c05791b8007747707c4796d"
-    },
-    {
-      "ref": "1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
+      "ref": "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
-        "f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31"
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "23aeadff4c49ed6fe259ceedace718a1b3a87758bb84f447a7233d6ef697b01a"
-    },
-    {
-      "ref": "2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
+      "ref": "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
-        "393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
-        "4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "5536aef1348089387c04172edddfa56e2ae144f384aa4871c035ab0d94621a47",
-        "5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6",
-        "5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
-        "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-        "80505eaaecd40e8d632b36a6b414965cfc0b258530b4ff005e2091cb84738e5f",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
-        "ac17ecc668ea148cef3ae5efafd0da41ee43e041354814546b344e76dd2064b2",
-        "ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
-        "d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
-        "d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
-        "de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
-        "e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
-        "e90ea37b7ba280946e6f55fc762d26f9122d8e6514b50b48a2d174f000526aaf",
-        "ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
-        "f3c01e9a7345dc4da30b88a2bbd076139b38d105e88dfe9e22984964eca03c59",
-        "f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31"
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+      "ref": "@angular/forms@20.3.17#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
       "dependsOn": [
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/material@20.2.14#2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
       "dependsOn": [
-        "87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/cdk@20.2.14#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/forms@20.3.17#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
+        "@angular/platform-browser@20.3.17#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
+      "ref": "@angular/platform-browser@20.3.17#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf"
+        "@angular/animations@20.3.17#87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
+      "ref": "@angular/router@20.3.17#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@20.3.17#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
+      "ref": "@ctrl/ngx-codemirror@7.0.0#54f3746bdae3b18da934798c490da1b34044aa8fd98714521bb76e38fd574568",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
-        "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26"
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/forms@20.3.17#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
+        "codemirror@5.65.21#c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3"
       ]
     },
     {
-      "ref": "2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-juice-shop-frontend@19.2.0-SNAPSHOT#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2"
-      ]
-    },
-    {
-      "ref": "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"
-    },
-    {
-      "ref": "393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a"
-      ]
-    },
-    {
-      "ref": "3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1",
-      "dependsOn": [
-        "VirtualComponent (disabled):buffer"
-      ]
-    },
-    {
-      "ref": "3e0945a272ea197886256c13e5d9d01ea14c18e8a345d0b5a14c524d3c316053"
-    },
-    {
-      "ref": "419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91",
-      "dependsOn": [
-        "1dcf4229ac09993c5669a6bbbd2a2c7781e5cddc8c05791b8007747707c4796d",
-        "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"
-      ]
-    },
-    {
-      "ref": "4463ae507d574f1c1e49f9e4523d3e45d2fb18df2ff83b1153c23aca4862db35"
-    },
-    {
-      "ref": "460939b68f8053fe278cb6210f7b2d9187940178fca9abf270d11ff80bda5aa0"
-    },
-    {
-      "ref": "470080acde1191c2f60340adb57cf459ed26b92c63755bf042f1cbb73fd164d6"
-    },
-    {
-      "ref": "49646800769b71f6867412afd9659b95d3915a506b240b81ed1f154f01ba25cb",
-      "dependsOn": [
-        "668fbe027e327ad3dae761769c6811220166b2e4087fcd0731a4599b571774f4"
-      ]
-    },
-    {
-      "ref": "4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
-        "b074eb1e67f059f163b11978fc996cde910b48835d456d4b37e2c7479e50eee6",
-        "be31b7812813f6cafff435a2474c37b4ced000ac0a994bd4513e822451a3f2b0",
-        "e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2"
-      ]
-    },
-    {
-      "ref": "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
-      ]
-    },
-    {
-      "ref": "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
-    },
-    {
-      "ref": "54f3746bdae3b18da934798c490da1b34044aa8fd98714521bb76e38fd574568",
-      "dependsOn": [
-        "c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556"
-      ]
-    },
-    {
-      "ref": "5536aef1348089387c04172edddfa56e2ae144f384aa4871c035ab0d94621a47",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf"
-      ]
-    },
-    {
-      "ref": "58e67da2ac79d3a7fb5463e0e89caa3346e3879ca25c384fc9a58b950e81cea0"
-    },
-    {
-      "ref": "593e2111acde3c2317ba496deb365ec7f1c6b3a8783dd53ed9572947c1a19079",
-      "dependsOn": [
-        "a630b0274ebf498dd93ac568af1ea4352b0f7d942f74cb84eb8c1fda518a45b1"
-      ]
-    },
-    {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
-    },
-    {
-      "ref": "5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6",
-      "dependsOn": [
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
-      ]
-    },
-    {
-      "ref": "5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1",
-        "419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
-      ]
-    },
-    {
-      "ref": "5e91ea783d620d2fd4ea7a5ec9e85d4c8c194e2f9c758a2a47893e4d100b9372",
-      "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26"
-      ]
-    },
-    {
-      "ref": "5ee3fef5d3e4bd3b22d71ad1e6126d725035e7ad5f4f4c977309af050e7ed6f8",
-      "dependsOn": [
-        "593e2111acde3c2317ba496deb365ec7f1c6b3a8783dd53ed9572947c1a19079",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
-      ]
-    },
-    {
-      "ref": "668fbe027e327ad3dae761769c6811220166b2e4087fcd0731a4599b571774f4"
-    },
-    {
-      "ref": "696641cb855cdee93723c8240382c89a8306a582d3991f0477fc57308d2d8014"
-    },
-    {
-      "ref": "6a0d1d6f94e6c564ed811d8e12383096c32bc5be56ee8ec1348cc932765b57a5",
-      "dependsOn": [
-        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.eot",
-        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.svg#font-mfizz",
-        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.ttf",
-        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.woff"
-      ]
-    },
-    {
-      "ref": "70465b851954084600d4d20d0e95204b6741f5a109d78a6f967612fb72974d70"
-    },
-    {
-      "ref": "707c94303cf21f2f18fbd2e689f593e0dd2dbeb2cfb65df8e62abc3917f3afd3"
-    },
-    {
-      "ref": "71cfcf50345fafd2898e8bf30ca83b02511aed3de0296baec389acb50b5798cc",
-      "dependsOn": [
-        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.eot",
-        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.ttf",
-        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.woff",
-        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.woff2"
-      ]
-    },
-    {
-      "ref": "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
-        "f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31"
-      ]
-    },
-    {
-      "ref": "782d1c52d92feccc4f974775dbac70403aee3f7762a947388268d2ca320c30c8",
-      "dependsOn": [
-        "0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
-        "11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f",
-        "9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487",
-        "aa5188dceffe08183a6d9a853dcefd9985f26040130ea31602286c6140b27556",
-        "e3886532e4f1634ce87c2148abd3b0ca4780fc5bee3e7e6b78cfb79bf8d5d9ad",
-        "fd1fc69cef6438a9e0f179bdf175b6f5c86e3e71c06e8d8b1f484b5507627f72"
-      ]
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "061ec3972fcd2bf843e949590c0c995be1d6d66f794edcc68d526957eb76d864",
-        "1387fa0e934f50384db142905d7f5c576ad88b3fbf172362ba3b14ee03a6a6f1",
-        "23aeadff4c49ed6fe259ceedace718a1b3a87758bb84f447a7233d6ef697b01a",
-        "2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
-        "3e0945a272ea197886256c13e5d9d01ea14c18e8a345d0b5a14c524d3c316053",
-        "470080acde1191c2f60340adb57cf459ed26b92c63755bf042f1cbb73fd164d6",
-        "54f3746bdae3b18da934798c490da1b34044aa8fd98714521bb76e38fd574568",
-        "5e91ea783d620d2fd4ea7a5ec9e85d4c8c194e2f9c758a2a47893e4d100b9372",
-        "5ee3fef5d3e4bd3b22d71ad1e6126d725035e7ad5f4f4c977309af050e7ed6f8",
-        "696641cb855cdee93723c8240382c89a8306a582d3991f0477fc57308d2d8014",
-        "782d1c52d92feccc4f974775dbac70403aee3f7762a947388268d2ca320c30c8",
-        "7f785beb037a50a59c946f3bb834293e69ab22dbb1682a86fa0528a6c4f2c790",
-        "831f9821b0124146e8b1eb11e80d61f049f39d393a417f0d74415e1a6d3e6970",
-        "87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a7422bca70966a5c31971b49a4771d1dd160303eda80fbb06cdd7d4140d5bd48",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-        "ae416b20d856a72845bd1d8a9a020de20852ea632cd9ecfb2f96f9276cfa6c4c",
-        "b27c1232e59e35a68d72eb621b561abc9d172ccb287f3e8db8d540922feeb403",
-        "b3dfb133d42f90885db89be033e4dadda7fd7e388b712c72e8e84c8087144a5a",
-        "b3f01bcff85de93ebb785b67f734367ea3b74c9d14c3b78b3445a69620f7efbe",
-        "c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3",
-        "ca565f4440a2bcd75007fbed65d41a7c4b6151bcf8a4d48c33024d085bf312ee",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
-        "d5d8583bb1a5f97cd8d06f96692707d51a1b8fcfe49348ded1bfdd156d6ff43e",
-        "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
-        "e593fc3d170f3673dcde127c885b2cd6c3a5d4ff59eea51dc518bd6d9d1720f3",
-        "f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18",
-        "f6c6d90a2f0fb70d0075b453208211ba2e79e559398d84ccbde8713427091759",
-        "fe9db2c2dcba6794c74deb46be575c01825056eda6a775af76e34f04db16f42a",
+        "@angular/animations@20.3.17#87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
+        "@angular/cdk@20.2.14#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/forms@20.3.17#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
+        "@angular/material@20.2.14#2b66e0d815fd656395401f2af66dfc700b28bd0cf7d9f3415ae8145fa32b3bd0",
+        "@angular/platform-browser@20.3.17#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "@angular/router@20.3.17#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+        "@ctrl/ngx-codemirror@7.0.0#54f3746bdae3b18da934798c490da1b34044aa8fd98714521bb76e38fd574568",
+        "@fortawesome/fontawesome-svg-core@1.2.36#3e0945a272ea197886256c13e5d9d01ea14c18e8a345d0b5a14c524d3c316053",
+        "@fortawesome/free-brands-svg-icons@5.15.4#23aeadff4c49ed6fe259ceedace718a1b3a87758bb84f447a7233d6ef697b01a",
+        "@fortawesome/free-regular-svg-icons@5.15.4#d5d8583bb1a5f97cd8d06f96692707d51a1b8fcfe49348ded1bfdd156d6ff43e",
+        "@fortawesome/free-solid-svg-icons@5.15.4#b27c1232e59e35a68d72eb621b561abc9d172ccb287f3e8db8d540922feeb403",
+        "@ngx-translate/core@15.0.0#a7422bca70966a5c31971b49a4771d1dd160303eda80fbb06cdd7d4140d5bd48",
+        "@ngx-translate/http-loader@8.0.0#696641cb855cdee93723c8240382c89a8306a582d3991f0477fc57308d2d8014",
+        "@wagmi/core@0.5.8#b3f01bcff85de93ebb785b67f734367ea3b74c9d14c3b78b3445a69620f7efbe",
+        "@winarg/ngx-text-diff@19.0.1#ae416b20d856a72845bd1d8a9a020de20852ea632cd9ecfb2f96f9276cfa6c4c",
+        "canvas-confetti@1.9.4#470080acde1191c2f60340adb57cf459ed26b92c63755bf042f1cbb73fd164d6",
+        "codemirror-solidity@0.2.5#1387fa0e934f50384db142905d7f5c576ad88b3fbf172362ba3b14ee03a6a6f1",
+        "codemirror@5.65.21#c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3",
+        "ethers@5.8.0#2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
+        "file-saver@2.0.5#e593fc3d170f3673dcde127c885b2cd6c3a5d4ff59eea51dc518bd6d9d1720f3",
+        "highlight.js@11.11.1#f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18",
+        "jwt-decode@2.2.0#fe9db2c2dcba6794c74deb46be575c01825056eda6a775af76e34f04db16f42a",
+        "lodash-es@4.17.23#831f9821b0124146e8b1eb11e80d61f049f39d393a417f0d74415e1a6d3e6970",
+        "ng-gallery@12.0.0#5e91ea783d620d2fd4ea7a5ec9e85d4c8c194e2f9c758a2a47893e4d100b9372",
+        "ng-qrcode@20.0.1#5ee3fef5d3e4bd3b22d71ad1e6126d725035e7ad5f4f4c977309af050e7ed6f8",
+        "ng2-file-upload@9.0.0#061ec3972fcd2bf843e949590c0c995be1d6d66f794edcc68d526957eb76d864",
+        "ngx-highlightjs@14.0.1#b3dfb133d42f90885db89be033e4dadda7fd7e388b712c72e8e84c8087144a5a",
+        "ngy-cookie@6.0.1000#f6c6d90a2f0fb70d0075b453208211ba2e79e559398d84ccbde8713427091759",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+        "snarkdown@1.2.2#ca565f4440a2bcd75007fbed65d41a7c4b6151bcf8a4d48c33024d085bf312ee",
+        "socket.io-client@3.1.3#782d1c52d92feccc4f974775dbac70403aee3f7762a947388268d2ca320c30c8",
+        "solidity-browser-compiler@1.1.0#7f785beb037a50a59c946f3bb834293e69ab22dbb1682a86fa0528a6c4f2c790",
         "VirtualComponent angular:polyfills:angular:polyfills",
         "VirtualComponent angular:script/global:scripts.js",
         "VirtualComponent angular:styles/global:styles"
       ]
     },
     {
-      "ref": "7c49e48d5f65924f5e8731ac61343484eacef2248600f5050c75e4737fde12eb"
-    },
-    {
-      "ref": "7f785beb037a50a59c946f3bb834293e69ab22dbb1682a86fa0528a6c4f2c790"
-    },
-    {
-      "ref": "80505eaaecd40e8d632b36a6b414965cfc0b258530b4ff005e2091cb84738e5f",
+      "ref": "@ethersproject/abi@5.8.0#1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
       "dependsOn": [
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/constants@5.8.0#f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
+        "@ethersproject/hash@5.8.0#2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864"
       ]
     },
     {
-      "ref": "831f9821b0124146e8b1eb11e80d61f049f39d393a417f0d74415e1a6d3e6970"
-    },
-    {
-      "ref": "87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
+      "ref": "@ethersproject/abstract-provider@5.8.0#292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
       "dependsOn": [
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316"
       ]
     },
     {
-      "ref": "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
+      "ref": "@ethersproject/abstract-signer@5.8.0#ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31"
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316"
       ]
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/rlp@5.8.0#d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2"
       ]
     },
     {
-      "ref": "97d4082d905bd7891eea5dcafbd82c9a89aa2617236cf546deca8231d3e82a58",
+      "ref": "@ethersproject/base64@5.8.0#393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
       "dependsOn": [
-        "d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a"
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a"
       ]
     },
     {
-      "ref": "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+      "ref": "@ethersproject/basex@5.8.0#9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "a19681ba3ff7a814b42c241beff8374c98b63794985df87ce6b75af891f67fc6"
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316"
       ]
     },
     {
-      "ref": "9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
+      "ref": "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316"
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "bn.js@5.2.3#3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1"
       ]
     },
     {
-      "ref": "9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487",
+      "ref": "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
       "dependsOn": [
-        "d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a"
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
       ]
     },
     {
-      "ref": "a19681ba3ff7a814b42c241beff8374c98b63794985df87ce6b75af891f67fc6"
-    },
-    {
-      "ref": "a630b0274ebf498dd93ac568af1ea4352b0f7d942f74cb84eb8c1fda518a45b1"
-    },
-    {
-      "ref": "a7422bca70966a5c31971b49a4771d1dd160303eda80fbb06cdd7d4140d5bd48",
+      "ref": "@ethersproject/constants@5.8.0#f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38"
       ]
     },
     {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "@ethersproject/contracts@5.8.0#ac17ecc668ea148cef3ae5efafd0da41ee43e041354814546b344e76dd2064b2",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@ethersproject/abi@5.8.0#1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
+        "@ethersproject/abstract-provider@5.8.0#292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
+        "@ethersproject/abstract-signer@5.8.0#ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145"
       ]
     },
     {
-      "ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "ref": "@ethersproject/hash@5.8.0#2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/base64@5.8.0#393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864"
       ]
     },
     {
-      "ref": "a9fd1742886a43e2cfcf3eafb8d805733241afaa1ab4dc856406fce056ca0a23"
-    },
-    {
-      "ref": "aa5188dceffe08183a6d9a853dcefd9985f26040130ea31602286c6140b27556"
-    },
-    {
-      "ref": "ac17ecc668ea148cef3ae5efafd0da41ee43e041354814546b344e76dd2064b2",
+      "ref": "@ethersproject/hdnode@5.8.0#ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
-        "ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67"
+        "@ethersproject/basex@5.8.0#9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/pbkdf2@5.8.0#28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/sha2@5.8.0#de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
+        "@ethersproject/signing-key@5.8.0#5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
+        "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
+        "@ethersproject/wordlists@5.8.0#5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6"
       ]
     },
     {
-      "ref": "ac8c40cfc6e68477fae3ea44ce291e60703c173fb49cc3f82f435c0c3fffb8b6",
+      "ref": "@ethersproject/json-wallets@5.8.0#4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
+      "dependsOn": [
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/hdnode@5.8.0#ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/pbkdf2@5.8.0#28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/random@5.8.0#e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
+        "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
+        "aes-js@3.0.0#b074eb1e67f059f163b11978fc996cde910b48835d456d4b37e2c7479e50eee6",
+        "scrypt-js@3.0.1#be31b7812813f6cafff435a2474c37b4ced000ac0a994bd4513e822451a3f2b0"
+      ]
+    },
+    {
+      "ref": "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+      "dependsOn": [
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "js-sha3@0.8.0#a19681ba3ff7a814b42c241beff8374c98b63794985df87ce6b75af891f67fc6"
+      ]
+    },
+    {
+      "ref": "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+    },
+    {
+      "ref": "@ethersproject/networks@5.8.0#f35ac392b09cf8b99413fc9bfe79c72437a652572314886cc09b0d397308ede7",
+      "dependsOn": [
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+      ]
+    },
+    {
+      "ref": "@ethersproject/pbkdf2@5.8.0#28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
+      "dependsOn": [
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/sha2@5.8.0#de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf"
+      ]
+    },
+    {
+      "ref": "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+      "dependsOn": [
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+      ]
+    },
+    {
+      "ref": "@ethersproject/providers@5.8.0#e90ea37b7ba280946e6f55fc762d26f9122d8e6514b50b48a2d174f000526aaf",
+      "dependsOn": [
+        "@ethersproject/abstract-provider@5.8.0#292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
+        "@ethersproject/abstract-signer@5.8.0#ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/base64@5.8.0#393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
+        "@ethersproject/basex@5.8.0#9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/constants@5.8.0#f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
+        "@ethersproject/hash@5.8.0#2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/networks@5.8.0#f35ac392b09cf8b99413fc9bfe79c72437a652572314886cc09b0d397308ede7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/random@5.8.0#e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
+        "@ethersproject/sha2@5.8.0#de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
+        "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
+        "@ethersproject/web@5.8.0#d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
+        "bech32@1.1.4#58e67da2ac79d3a7fb5463e0e89caa3346e3879ca25c384fc9a58b950e81cea0"
+      ]
+    },
+    {
+      "ref": "@ethersproject/random@5.8.0#e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
+      "dependsOn": [
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+      ]
+    },
+    {
+      "ref": "@ethersproject/rlp@5.8.0#d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
+      "dependsOn": [
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+      ]
+    },
+    {
+      "ref": "@ethersproject/sha2@5.8.0#de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
+      "dependsOn": [
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "hash.js@1.1.7#419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91"
+      ]
+    },
+    {
+      "ref": "@ethersproject/signing-key@5.8.0#5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
+      "dependsOn": [
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "bn.js@5.2.3#3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1",
+        "hash.js@1.1.7#419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91"
+      ]
+    },
+    {
+      "ref": "@ethersproject/solidity@5.8.0#5536aef1348089387c04172edddfa56e2ae144f384aa4871c035ab0d94621a47",
+      "dependsOn": [
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/sha2@5.8.0#de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864"
+      ]
+    },
+    {
+      "ref": "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
+      "dependsOn": [
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/constants@5.8.0#f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+      ]
+    },
+    {
+      "ref": "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
+      "dependsOn": [
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/constants@5.8.0#f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/rlp@5.8.0#d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
+        "@ethersproject/signing-key@5.8.0#5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162"
+      ]
+    },
+    {
+      "ref": "@ethersproject/units@5.8.0#80505eaaecd40e8d632b36a6b414965cfc0b258530b4ff005e2091cb84738e5f",
+      "dependsOn": [
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+      ]
+    },
+    {
+      "ref": "@ethersproject/wallet@5.8.0#f3c01e9a7345dc4da30b88a2bbd076139b38d105e88dfe9e22984964eca03c59",
+      "dependsOn": [
+        "@ethersproject/abstract-provider@5.8.0#292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
+        "@ethersproject/abstract-signer@5.8.0#ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/hash@5.8.0#2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
+        "@ethersproject/hdnode@5.8.0#ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
+        "@ethersproject/json-wallets@5.8.0#4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/random@5.8.0#e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
+        "@ethersproject/signing-key@5.8.0#5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
+        "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145"
+      ]
+    },
+    {
+      "ref": "@ethersproject/web@5.8.0#d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
+      "dependsOn": [
+        "@ethersproject/base64@5.8.0#393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864"
+      ]
+    },
+    {
+      "ref": "@ethersproject/wordlists@5.8.0#5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6",
+      "dependsOn": [
+        "@ethersproject/hash@5.8.0#2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316"
+      ]
+    },
+    {
+      "ref": "@fortawesome/fontawesome-svg-core@1.2.36#3e0945a272ea197886256c13e5d9d01ea14c18e8a345d0b5a14c524d3c316053"
+    },
+    {
+      "ref": "@fortawesome/free-brands-svg-icons@5.15.4#23aeadff4c49ed6fe259ceedace718a1b3a87758bb84f447a7233d6ef697b01a"
+    },
+    {
+      "ref": "@fortawesome/free-regular-svg-icons@5.15.4#d5d8583bb1a5f97cd8d06f96692707d51a1b8fcfe49348ded1bfdd156d6ff43e"
+    },
+    {
+      "ref": "@fortawesome/free-solid-svg-icons@5.15.4#b27c1232e59e35a68d72eb621b561abc9d172ccb287f3e8db8d540922feeb403"
+    },
+    {
+      "ref": "@ngx-translate/core@15.0.0#a7422bca70966a5c31971b49a4771d1dd160303eda80fbb06cdd7d4140d5bd48",
+      "dependsOn": [
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+      ]
+    },
+    {
+      "ref": "@ngx-translate/http-loader@8.0.0#696641cb855cdee93723c8240382c89a8306a582d3991f0477fc57308d2d8014"
+    },
+    {
+      "ref": "@wagmi/core@0.5.8#b3f01bcff85de93ebb785b67f734367ea3b74c9d14c3b78b3445a69620f7efbe",
+      "dependsOn": [
+        "ethers@5.8.0#2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
+        "eventemitter3@4.0.7#a9fd1742886a43e2cfcf3eafb8d805733241afaa1ab4dc856406fce056ca0a23",
+        "zustand@4.5.7#d579e4c38840ee6a708f796b6704861f3200d22c47c6d7d462eff784818c5aa0"
+      ]
+    },
+    {
+      "ref": "@winarg/ngx-text-diff@19.0.1#ae416b20d856a72845bd1d8a9a020de20852ea632cd9ecfb2f96f9276cfa6c4c",
+      "dependsOn": [
+        "@angular/cdk@20.2.14#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/forms@20.3.17#ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
+        "diff-match-patch@1.0.5#707c94303cf21f2f18fbd2e689f593e0dd2dbeb2cfb65df8e62abc3917f3afd3"
+      ]
+    },
+    {
+      "ref": "aes-js@3.0.0#b074eb1e67f059f163b11978fc996cde910b48835d456d4b37e2c7479e50eee6"
+    },
+    {
+      "ref": "backo2@1.0.2#aa5188dceffe08183a6d9a853dcefd9985f26040130ea31602286c6140b27556"
+    },
+    {
+      "ref": "base64-arraybuffer@0.1.4#668fbe027e327ad3dae761769c6811220166b2e4087fcd0731a4599b571774f4"
+    },
+    {
+      "ref": "bech32@1.1.4#58e67da2ac79d3a7fb5463e0e89caa3346e3879ca25c384fc9a58b950e81cea0"
+    },
+    {
+      "ref": "bn.js@5.2.3#3d17fdea7fb6a6037f95bf0645b51b98916d161efe0ca72ae4dd55736c4b42b1",
+      "dependsOn": [
+        "VirtualComponent (disabled):buffer"
+      ]
+    },
+    {
+      "ref": "canvas-confetti@1.9.4#470080acde1191c2f60340adb57cf459ed26b92c63755bf042f1cbb73fd164d6"
+    },
+    {
+      "ref": "codemirror-solidity@0.2.5#1387fa0e934f50384db142905d7f5c576ad88b3fbf172362ba3b14ee03a6a6f1"
+    },
+    {
+      "ref": "codemirror@5.65.21#c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3"
+    },
+    {
+      "ref": "component-emitter@1.3.1#0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c"
+    },
+    {
+      "ref": "cookieconsent@3.1.1#70465b851954084600d4d20d0e95204b6741f5a109d78a6f967612fb72974d70"
+    },
+    {
+      "ref": "debug@4.3.7#97d4082d905bd7891eea5dcafbd82c9a89aa2617236cf546deca8231d3e82a58",
+      "dependsOn": [
+        "ms@2.1.3#d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a"
+      ]
+    },
+    {
+      "ref": "debug@4.3.7#9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487",
+      "dependsOn": [
+        "ms@2.1.3#d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a"
+      ]
+    },
+    {
+      "ref": "diff-match-patch@1.0.5#707c94303cf21f2f18fbd2e689f593e0dd2dbeb2cfb65df8e62abc3917f3afd3"
+    },
+    {
+      "ref": "dijkstrajs@1.0.3#a630b0274ebf498dd93ac568af1ea4352b0f7d942f74cb84eb8c1fda518a45b1"
+    },
+    {
+      "ref": "engine.io-client@4.1.4#fd1fc69cef6438a9e0f179bdf175b6f5c86e3e71c06e8d8b1f484b5507627f72",
+      "dependsOn": [
+        "component-emitter@1.3.1#0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
+        "debug@4.3.7#97d4082d905bd7891eea5dcafbd82c9a89aa2617236cf546deca8231d3e82a58",
+        "engine.io-parser@4.0.3#49646800769b71f6867412afd9659b95d3915a506b240b81ed1f154f01ba25cb",
+        "has-cors@1.1.0#4463ae507d574f1c1e49f9e4523d3e45d2fb18df2ff83b1153c23aca4862db35",
+        "parseqs@0.0.6#7c49e48d5f65924f5e8731ac61343484eacef2248600f5050c75e4737fde12eb",
+        "parseuri@0.0.6#11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f",
+        "yeast@0.1.2#460939b68f8053fe278cb6210f7b2d9187940178fca9abf270d11ff80bda5aa0"
+      ]
+    },
+    {
+      "ref": "engine.io-parser@4.0.3#49646800769b71f6867412afd9659b95d3915a506b240b81ed1f154f01ba25cb",
+      "dependsOn": [
+        "base64-arraybuffer@0.1.4#668fbe027e327ad3dae761769c6811220166b2e4087fcd0731a4599b571774f4"
+      ]
+    },
+    {
+      "ref": "ethers@5.8.0#2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
+      "dependsOn": [
+        "@ethersproject/abi@5.8.0#1dda7d82dd765b0f8f2bec33b32522334de7d311fc1765e62c5add1289617225",
+        "@ethersproject/abstract-signer@5.8.0#ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
+        "@ethersproject/address@5.8.0#e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
+        "@ethersproject/base64@5.8.0#393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
+        "@ethersproject/basex@5.8.0#9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
+        "@ethersproject/bignumber@5.8.0#535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
+        "@ethersproject/bytes@5.8.0#1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
+        "@ethersproject/constants@5.8.0#f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
+        "@ethersproject/contracts@5.8.0#ac17ecc668ea148cef3ae5efafd0da41ee43e041354814546b344e76dd2064b2",
+        "@ethersproject/hash@5.8.0#2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
+        "@ethersproject/hdnode@5.8.0#ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
+        "@ethersproject/json-wallets@5.8.0#4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
+        "@ethersproject/keccak256@5.8.0#993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
+        "@ethersproject/logger@5.8.0#53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
+        "@ethersproject/properties@5.8.0#25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
+        "@ethersproject/providers@5.8.0#e90ea37b7ba280946e6f55fc762d26f9122d8e6514b50b48a2d174f000526aaf",
+        "@ethersproject/random@5.8.0#e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
+        "@ethersproject/rlp@5.8.0#d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
+        "@ethersproject/sha2@5.8.0#de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
+        "@ethersproject/signing-key@5.8.0#5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
+        "@ethersproject/solidity@5.8.0#5536aef1348089387c04172edddfa56e2ae144f384aa4871c035ab0d94621a47",
+        "@ethersproject/strings@5.8.0#8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
+        "@ethersproject/transactions@5.8.0#7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
+        "@ethersproject/units@5.8.0#80505eaaecd40e8d632b36a6b414965cfc0b258530b4ff005e2091cb84738e5f",
+        "@ethersproject/wallet@5.8.0#f3c01e9a7345dc4da30b88a2bbd076139b38d105e88dfe9e22984964eca03c59",
+        "@ethersproject/web@5.8.0#d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
+        "@ethersproject/wordlists@5.8.0#5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6"
+      ]
+    },
+    {
+      "ref": "eventemitter3@4.0.7#a9fd1742886a43e2cfcf3eafb8d805733241afaa1ab4dc856406fce056ca0a23"
+    },
+    {
+      "ref": "file-saver@2.0.5#e593fc3d170f3673dcde127c885b2cd6c3a5d4ff59eea51dc518bd6d9d1720f3"
+    },
+    {
+      "ref": "flag-icons@6.15.0#ac8c40cfc6e68477fae3ea44ce291e60703c173fb49cc3f82f435c0c3fffb8b6",
       "dependsOn": [
         "VirtualComponent angular:css-resource:node_modules/flag-icons/flags/1x1/ad.svg",
         "VirtualComponent angular:css-resource:node_modules/flag-icons/flags/1x1/ae.svg",
@@ -12826,233 +12907,143 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
       ]
     },
     {
-      "ref": "ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
+      "ref": "font-mfizz@2.4.1#6a0d1d6f94e6c564ed811d8e12383096c32bc5be56ee8ec1348cc932765b57a5",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "28180490144b46547ccf460a6779a428125f45a469d31d3364fa52049123de5f",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "5bd60f2be37c0195a79f0a476d60478006caadb567990f80f017a4f6f734d3c6",
-        "5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
-        "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-        "9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
-        "de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf"
+        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.eot",
+        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.svg#font-mfizz",
+        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.ttf",
+        "VirtualComponent angular:css-resource:node_modules/font-mfizz/dist/font-mfizz.woff"
       ]
     },
     {
-      "ref": "ae416b20d856a72845bd1d8a9a020de20852ea632cd9ecfb2f96f9276cfa6c4c",
+      "ref": "has-cors@1.1.0#4463ae507d574f1c1e49f9e4523d3e45d2fb18df2ff83b1153c23aca4862db35"
+    },
+    {
+      "ref": "hash.js@1.1.7#419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91",
       "dependsOn": [
-        "707c94303cf21f2f18fbd2e689f593e0dd2dbeb2cfb65df8e62abc3917f3afd3",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
-        "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26"
+        "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+        "minimalistic-assert@1.0.1#1dcf4229ac09993c5669a6bbbd2a2c7781e5cddc8c05791b8007747707c4796d"
       ]
     },
     {
-      "ref": "b074eb1e67f059f163b11978fc996cde910b48835d456d4b37e2c7479e50eee6"
+      "ref": "highlight.js@11.11.1#f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18"
     },
     {
-      "ref": "b27c1232e59e35a68d72eb621b561abc9d172ccb287f3e8db8d540922feeb403"
+      "ref": "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"
     },
     {
-      "ref": "b3dfb133d42f90885db89be033e4dadda7fd7e388b712c72e8e84c8087144a5a",
+      "ref": "js-sha3@0.8.0#a19681ba3ff7a814b42c241beff8374c98b63794985df87ce6b75af891f67fc6"
+    },
+    {
+      "ref": "jwt-decode@2.2.0#fe9db2c2dcba6794c74deb46be575c01825056eda6a775af76e34f04db16f42a"
+    },
+    {
+      "ref": "lodash-es@4.17.23#831f9821b0124146e8b1eb11e80d61f049f39d393a417f0d74415e1a6d3e6970"
+    },
+    {
+      "ref": "material-icons@0.3.1#71cfcf50345fafd2898e8bf30ca83b02511aed3de0296baec389acb50b5798cc",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.eot",
+        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.ttf",
+        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.woff",
+        "VirtualComponent angular:css-resource:node_modules/material-icons/iconfont/MaterialIcons-Regular.woff2"
       ]
     },
     {
-      "ref": "b3f01bcff85de93ebb785b67f734367ea3b74c9d14c3b78b3445a69620f7efbe",
+      "ref": "minimalistic-assert@1.0.1#1dcf4229ac09993c5669a6bbbd2a2c7781e5cddc8c05791b8007747707c4796d"
+    },
+    {
+      "ref": "ms@2.1.3#d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a"
+    },
+    {
+      "ref": "ng-gallery@12.0.0#5e91ea783d620d2fd4ea7a5ec9e85d4c8c194e2f9c758a2a47893e4d100b9372",
       "dependsOn": [
-        "2443d85f8dcf7aa1b365b5a6ec55cfdef49c350f7e314182d9324ba1ec851876",
-        "a9fd1742886a43e2cfcf3eafb8d805733241afaa1ab4dc856406fce056ca0a23",
-        "d579e4c38840ee6a708f796b6704861f3200d22c47c6d7d462eff784818c5aa0"
+        "@angular/animations@20.3.17#87eef182df0bb2fa38a287832ab97f4779eb488f5af279a4bccf3a9a47a94e36",
+        "@angular/cdk@20.2.14#e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@20.3.17#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "be31b7812813f6cafff435a2474c37b4ced000ac0a994bd4513e822451a3f2b0"
-    },
-    {
-      "ref": "c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3"
-    },
-    {
-      "ref": "ca565f4440a2bcd75007fbed65d41a7c4b6151bcf8a4d48c33024d085bf312ee"
-    },
-    {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
-    },
-    {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "ref": "ng-qrcode@20.0.1#5ee3fef5d3e4bd3b22d71ad1e6126d725035e7ad5f4f4c977309af050e7ed6f8",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "qrcode@1.5.4#593e2111acde3c2317ba496deb365ec7f1c6b3a8783dd53ed9572947c1a19079"
       ]
     },
     {
-      "ref": "ced3abbccad68251caf80cf1273f1e82f20a10264f38394f27fcd253922a5556",
+      "ref": "ng2-file-upload@9.0.0#061ec3972fcd2bf843e949590c0c995be1d6d66f794edcc68d526957eb76d864",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "d4068a82eb6fb460927f3e5138673b47d5ea22965e07299d841824491768aa2a"
-    },
-    {
-      "ref": "d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2",
+      "ref": "ngx-highlightjs@14.0.1#b3dfb133d42f90885db89be033e4dadda7fd7e388b712c72e8e84c8087144a5a",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@20.3.17#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "d579e4c38840ee6a708f796b6704861f3200d22c47c6d7d462eff784818c5aa0"
-    },
-    {
-      "ref": "d5d8583bb1a5f97cd8d06f96692707d51a1b8fcfe49348ded1bfdd156d6ff43e"
-    },
-    {
-      "ref": "d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
+      "ref": "ngy-cookie@6.0.1000#f6c6d90a2f0fb70d0075b453208211ba2e79e559398d84ccbde8713427091759",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864"
+        "@angular/common@20.3.17#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@20.3.17#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
+      "ref": "parseqs@0.0.6#7c49e48d5f65924f5e8731ac61343484eacef2248600f5050c75e4737fde12eb"
+    },
+    {
+      "ref": "parseuri@0.0.6#11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f"
+    },
+    {
+      "ref": "qrcode@1.5.4#593e2111acde3c2317ba496deb365ec7f1c6b3a8783dd53ed9572947c1a19079",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "419ea612196efe2ed7f267c07dd9133e23f071977196c0ecf4d43589d64d2d91",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+        "dijkstrajs@1.0.3#a630b0274ebf498dd93ac568af1ea4352b0f7d942f74cb84eb8c1fda518a45b1"
       ]
     },
     {
-      "ref": "e02de73e1997dc4009d55b9bb4282baaf57f3d711520e89384e80ff9807b5c26",
+      "ref": "rxjs@7.8.2#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "tslib@2.8.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "e3886532e4f1634ce87c2148abd3b0ca4780fc5bee3e7e6b78cfb79bf8d5d9ad",
+      "ref": "scrypt-js@3.0.1#be31b7812813f6cafff435a2474c37b4ced000ac0a994bd4513e822451a3f2b0"
+    },
+    {
+      "ref": "snarkdown@1.2.2#ca565f4440a2bcd75007fbed65d41a7c4b6151bcf8a4d48c33024d085bf312ee"
+    },
+    {
+      "ref": "socket.io-client@3.1.3#782d1c52d92feccc4f974775dbac70403aee3f7762a947388268d2ca320c30c8",
       "dependsOn": [
-        "0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
-        "9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487"
+        "backo2@1.0.2#aa5188dceffe08183a6d9a853dcefd9985f26040130ea31602286c6140b27556",
+        "component-emitter@1.3.1#0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
+        "debug@4.3.7#9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487",
+        "engine.io-client@4.1.4#fd1fc69cef6438a9e0f179bdf175b6f5c86e3e71c06e8d8b1f484b5507627f72",
+        "parseuri@0.0.6#11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f",
+        "socket.io-parser@4.0.5#e3886532e4f1634ce87c2148abd3b0ca4780fc5bee3e7e6b78cfb79bf8d5d9ad"
       ]
     },
     {
-      "ref": "e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
+      "ref": "socket.io-parser@4.0.5#e3886532e4f1634ce87c2148abd3b0ca4780fc5bee3e7e6b78cfb79bf8d5d9ad",
       "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
+        "component-emitter@1.3.1#0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
+        "debug@4.3.7#9fa1a339a8e1eeda5a890aed9c55ea71b7aa195f08992042af58a3cdbf54f487"
       ]
     },
     {
-      "ref": "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "d5154b3442e6ef69e1bec3b78059ba9d51f1db8da869314870df787a796240d2"
-      ]
+      "ref": "solidity-browser-compiler@1.1.0#7f785beb037a50a59c946f3bb834293e69ab22dbb1682a86fa0528a6c4f2c790"
     },
     {
-      "ref": "e593fc3d170f3673dcde127c885b2cd6c3a5d4ff59eea51dc518bd6d9d1720f3"
-    },
-    {
-      "ref": "e90ea37b7ba280946e6f55fc762d26f9122d8e6514b50b48a2d174f000526aaf",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
-        "2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
-        "393eb6e06a319235e088924b73b4438be43ff12c47f1df9586845cfd047380bf",
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "58e67da2ac79d3a7fb5463e0e89caa3346e3879ca25c384fc9a58b950e81cea0",
-        "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-        "8a69234f812645e2ff8abfd21dd3c44af8b652f63a485be52a942c63ec046864",
-        "9da59bdb1a334be465043e4ac03d5a7de191f13ba983ddd8fb71bfbbbfd868ba",
-        "d97faa27755f8032c29ea160f91a93366b66fef6f9b5bb52b7fa2a5da5fe1226",
-        "de9a083d93d38da93653212f8c5dff4fc42a1f0306281e64f8b8c2de094703cf",
-        "e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
-        "ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
-        "f35ac392b09cf8b99413fc9bfe79c72437a652572314886cc09b0d397308ede7",
-        "f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31"
-      ]
-    },
-    {
-      "ref": "ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67",
-      "dependsOn": [
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
-      ]
-    },
-    {
-      "ref": "f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18"
-    },
-    {
-      "ref": "f35ac392b09cf8b99413fc9bfe79c72437a652572314886cc09b0d397308ede7",
-      "dependsOn": [
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7"
-      ]
-    },
-    {
-      "ref": "f3c01e9a7345dc4da30b88a2bbd076139b38d105e88dfe9e22984964eca03c59",
-      "dependsOn": [
-        "1b7e07a947b8ff6366ba248683391f1bf8bf003b4b2e9d433f970dd6904c185a",
-        "25b1206104eedabbf17f059036d46af51dff69d8e9aa6149b9b6721c46146316",
-        "292292af88dca3107cf13d8343919e4114328ce200be79ac38f881b80dbe7815",
-        "2d7d3eb933ddb803c5600683a6b6d12f9d1467b7e017197b071f0208453c57a6",
-        "4a0ffcfee556a7eac1e912e9af349fa2dc76cf6a2f214a7da9199951284f5890",
-        "53d4f1bb70d7d72e777c527b0de8ff8d0b603ac8071e58d0e5a58cc529728fb7",
-        "5cd75c38ac3ff733b055fb15fbd89432a0d16e2e00901c0b217407d9b779b162",
-        "7612bef6f1096268d14302da30aaf8521d794b4b8b87aed1611e98531b33d145",
-        "993e8fad75fe89ff10685c32b3acf9f9e027b64e895a624502e2331ccaa21a15",
-        "ae162a165d2aa735dec5978f170050131709a7b5f8e20b71b055d4ab7b29798b",
-        "e46ba3d4d47b59bc2b79075b24164d4d4bfcaa045f9e6290fd91de184e2f1b05",
-        "e4be0d4c1624ece12211201c928193a25eb5fbbf5f118c547f6c337e022ef7f2",
-        "ea1676c667dd4ac55f931dac69134c82b39ed09d2031d9698e75fe5b74ce9b67"
-      ]
-    },
-    {
-      "ref": "f6041988eb07fde3e2051ae53348e88c6a6813ad485a9aad86c1810ab9593c31",
-      "dependsOn": [
-        "535e98fd3f445101ccca376b01636c25cd2efa06f9bce2e7dfce2260fb424d38"
-      ]
-    },
-    {
-      "ref": "f6c6d90a2f0fb70d0075b453208211ba2e79e559398d84ccbde8713427091759",
-      "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
-      ]
-    },
-    {
-      "ref": "fd1fc69cef6438a9e0f179bdf175b6f5c86e3e71c06e8d8b1f484b5507627f72",
-      "dependsOn": [
-        "0f988efab05ee905ad470522d5386d239cc7a616de02b3f1ca7b7407f1383d3c",
-        "11741b72fc61b8c67fb779a3f47b201319ae8dfc0812ef22bf7b9c9179e2e11f",
-        "4463ae507d574f1c1e49f9e4523d3e45d2fb18df2ff83b1153c23aca4862db35",
-        "460939b68f8053fe278cb6210f7b2d9187940178fca9abf270d11ff80bda5aa0",
-        "49646800769b71f6867412afd9659b95d3915a506b240b81ed1f154f01ba25cb",
-        "7c49e48d5f65924f5e8731ac61343484eacef2248600f5050c75e4737fde12eb",
-        "97d4082d905bd7891eea5dcafbd82c9a89aa2617236cf546deca8231d3e82a58"
-      ]
-    },
-    {
-      "ref": "fe9db2c2dcba6794c74deb46be575c01825056eda6a775af76e34f04db16f42a"
+      "ref": "tslib@2.8.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
     },
     {
       "ref": "VirtualComponent (disabled):buffer"
@@ -14704,7 +14695,7 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     {
       "ref": "VirtualComponent angular:polyfills:angular:polyfills",
       "dependsOn": [
-        "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
+        "zone.js@0.15.1#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
       ]
     },
     {
@@ -14713,14 +14704,23 @@ exports[`integration functional: juice-shop frontend on npm generated json file:
     {
       "ref": "VirtualComponent angular:styles/global:styles",
       "dependsOn": [
-        "6a0d1d6f94e6c564ed811d8e12383096c32bc5be56ee8ec1348cc932765b57a5",
-        "70465b851954084600d4d20d0e95204b6741f5a109d78a6f967612fb72974d70",
-        "71cfcf50345fafd2898e8bf30ca83b02511aed3de0296baec389acb50b5798cc",
-        "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-        "ac8c40cfc6e68477fae3ea44ce291e60703c173fb49cc3f82f435c0c3fffb8b6",
-        "c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3",
-        "f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18"
+        "@cyclonedx/cyclonedx-eslint-testbed-juice-shop-frontend@19.2.0-SNAPSHOT#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+        "codemirror@5.65.21#c1d30dea75fae9e9fe5989dab26cd6fe656001eb7dec0dbe9ba453ecb1ae56d3",
+        "cookieconsent@3.1.1#70465b851954084600d4d20d0e95204b6741f5a109d78a6f967612fb72974d70",
+        "flag-icons@6.15.0#ac8c40cfc6e68477fae3ea44ce291e60703c173fb49cc3f82f435c0c3fffb8b6",
+        "font-mfizz@2.4.1#6a0d1d6f94e6c564ed811d8e12383096c32bc5be56ee8ec1348cc932765b57a5",
+        "highlight.js@11.11.1#f0ca8ac44951a4aa19a6a395957f8f8adbd96046fecdafd203c1a7fd10676c18",
+        "material-icons@0.3.1#71cfcf50345fafd2898e8bf30ca83b02511aed3de0296baec389acb50b5798cc"
       ]
+    },
+    {
+      "ref": "yeast@0.1.2#460939b68f8053fe278cb6210f7b2d9187940178fca9abf270d11ff80bda5aa0"
+    },
+    {
+      "ref": "zone.js@0.15.1#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
+    },
+    {
+      "ref": "zustand@4.5.7#d579e4c38840ee6a708f796b6704861f3200d22c47c6d7d462eff784818c5aa0"
     }
   ]
 }"
@@ -14816,7 +14816,7 @@ exports[`integration functional: no tree-shaking generated json file: dist/bom.j
       "name": "cyclonedx-eslint-testbed-no-treeshaking",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-no-treeshaking@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "Example using esbuild wit the latest supported version",
       "licenses": [
         {
@@ -14836,7 +14836,7 @@ exports[`integration functional: no tree-shaking generated json file: dist/bom.j
       "name": "cyclonedx-eslint-testing-custom-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
       "description": "this is a dummy package for showcasing purposes only.\\n",
       "scope": "required",
       "licenses": [
@@ -14868,7 +14868,7 @@ exports[`integration functional: no tree-shaking generated json file: dist/bom.j
       "name": "cyclonedx-eslint-testing-reexport-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "required",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
@@ -14877,18 +14877,18 @@ exports[`integration functional: no tree-shaking generated json file: dist/bom.j
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-no-treeshaking@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0"
+        "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0"
       ]
     },
     {
-      "ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
     },
     {
-      "ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "dependsOn": [
-        "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+        "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
       ]
     }
   ]
@@ -14985,7 +14985,7 @@ exports[`integration functional: package name is non-standard generated json fil
       "name": "cyclonedx-eslint-testbed-with-non-standard-name/testbed",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-with-non-standard-name/testbed@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "Example using a name that is not standard to https://www.npmjs.com/",
       "licenses": [
         {
@@ -15002,7 +15002,7 @@ exports[`integration functional: package name is non-standard generated json fil
   "components": [],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-with-non-standard-name/testbed@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
     }
   ]
 }"
@@ -15093,7 +15093,7 @@ exports[`integration functional: react19 on bun generated json file: dist/bom.js
       "name": "cyclonedx-eslint-testbed-react19-bun",
       "group": "@cyclonedx",
       "version": "0.1.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-react19-bun@0.1.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testbed-react19-bun@0.1.0",
       "evidence": {}
     }
@@ -15103,7 +15103,7 @@ exports[`integration functional: react19 on bun generated json file: dist/bom.js
       "type": "library",
       "name": "react-dom",
       "version": "19.2.4",
-      "bom-ref": "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+      "bom-ref": "react-dom@19.2.4#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
       "description": "React package for working with the DOM.",
       "scope": "required",
       "licenses": [
@@ -15149,57 +15149,9 @@ exports[`integration functional: react19 on bun generated json file: dist/bom.js
     },
     {
       "type": "library",
-      "name": "scheduler",
-      "version": "0.27.0",
-      "bom-ref": "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
-      "description": "Cooperative scheduler for the browser environment.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/scheduler@0.27.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler",
-      "externalReferences": [
-        {
-          "url": "https://github.com/facebook/react/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/facebook/react.git#packages/scheduler",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://react.dev/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgTWV0YSBQbGF0Zm9ybXMsIEluYy4gYW5kIGFmZmlsaWF0ZXMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbApjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFClNPRlRXQVJFLgo=",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "react",
       "version": "19.2.4",
-      "bom-ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+      "bom-ref": "react@19.2.4#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
       "description": "React is a JavaScript library for building user interfaces.",
       "scope": "required",
       "licenses": [
@@ -15242,27 +15194,75 @@ exports[`integration functional: react19 on bun generated json file: dist/bom.js
           }
         ]
       }
+    },
+    {
+      "type": "library",
+      "name": "scheduler",
+      "version": "0.27.0",
+      "bom-ref": "scheduler@0.27.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
+      "description": "Cooperative scheduler for the browser environment.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/scheduler@0.27.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/scheduler",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://react.dev/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgTWV0YSBQbGF0Zm9ybXMsIEluYy4gYW5kIGFmZmlsaWF0ZXMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbApjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFClNPRlRXQVJFLgo=",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
     }
   ],
   "dependencies": [
     {
-      "ref": "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-react19-bun@0.1.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
+        "react-dom@19.2.4#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+        "react@19.2.4#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
       ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "react-dom@19.2.4#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
       "dependsOn": [
-        "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+        "scheduler@0.27.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
       ]
     },
     {
-      "ref": "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
+      "ref": "react@19.2.4#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
     },
     {
-      "ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+      "ref": "scheduler@0.27.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
     }
   ]
 }"
@@ -15358,7 +15358,7 @@ exports[`integration functional: runtime-dependencies are external generated jso
       "name": "cyclonedx-eslint-testbed-with-externals",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-with-externals@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "Example using esbuild wit external components",
       "licenses": [
         {
@@ -15375,7 +15375,7 @@ exports[`integration functional: runtime-dependencies are external generated jso
   "components": [],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-with-externals@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
     }
   ]
 }"
@@ -15471,7 +15471,7 @@ exports[`integration functional: simple typescript bundling on npm generated jso
       "name": "cyclonedx-eslint-testbed-typescript-npm",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-typescript-npm@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "TypeScript example using esbuild with npm",
       "licenses": [
         {
@@ -15491,7 +15491,7 @@ exports[`integration functional: simple typescript bundling on npm generated jso
       "name": "cyclonedx-eslint-testing-custom-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668",
       "description": "this is a dummy package for showcasing purposes only.\\n",
       "scope": "required",
       "licenses": [
@@ -15523,7 +15523,7 @@ exports[`integration functional: simple typescript bundling on npm generated jso
       "name": "cyclonedx-eslint-testing-reexport-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "description": "this is a dummy package for showcasing purposes only.",
       "scope": "excluded",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
@@ -15532,18 +15532,18 @@ exports[`integration functional: simple typescript bundling on npm generated jso
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-typescript-npm@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0"
+        "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0"
       ]
     },
     {
-      "ref": "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
     },
     {
-      "ref": "eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#eef61cb816b4870cc41baae9389ed9b4f74713feb1532232bdb0bd65efa268d0",
       "dependsOn": [
-        "934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
+        "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#934cae484a0df083dc3c0dc4dfccd2d691cf53edd0986e89190924f73e840668"
       ]
     }
   ]
@@ -15640,7 +15640,7 @@ exports[`integration functional: simple typescript bundling on yarn generated js
       "name": "cyclonedx-eslint-testbed-typescript-yarn",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-typescript-yarn@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "TypeScript example using esbuild with Yarn 4",
       "licenses": [
         {
@@ -15657,21 +15657,10 @@ exports[`integration functional: simple typescript bundling on yarn generated js
   "components": [
     {
       "type": "library",
-      "name": "cyclonedx-eslint-testing-reexport-package",
-      "group": "@cyclonedx",
-      "version": "0.0.1",
-      "bom-ref": "4407577ae52a8e0b1426675fc484aef8bcb0be37d7d025e1bf12586b8e5056ce",
-      "description": "this is a dummy package for showcasing purposes only.",
-      "scope": "excluded",
-      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
-      "evidence": {}
-    },
-    {
-      "type": "library",
       "name": "cyclonedx-eslint-testing-custom-package",
       "group": "@cyclonedx",
       "version": "0.0.1",
-      "bom-ref": "ac73be2c234f2bbc42fbdf7561dee01c7d63ad117c6e199b46f9f3f6c651ddba",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#ac73be2c234f2bbc42fbdf7561dee01c7d63ad117c6e199b46f9f3f6c651ddba",
       "description": "this is a dummy package for showcasing purposes only.\\n",
       "scope": "required",
       "licenses": [
@@ -15697,23 +15686,34 @@ exports[`integration functional: simple typescript bundling on yarn generated js
           }
         ]
       }
+    },
+    {
+      "type": "library",
+      "name": "cyclonedx-eslint-testing-reexport-package",
+      "group": "@cyclonedx",
+      "version": "0.0.1",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#4407577ae52a8e0b1426675fc484aef8bcb0be37d7d025e1bf12586b8e5056ce",
+      "description": "this is a dummy package for showcasing purposes only.",
+      "scope": "excluded",
+      "purl": "pkg:npm/%40cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1",
+      "evidence": {}
     }
   ],
   "dependencies": [
     {
-      "ref": "4407577ae52a8e0b1426675fc484aef8bcb0be37d7d025e1bf12586b8e5056ce",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-typescript-yarn@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "ac73be2c234f2bbc42fbdf7561dee01c7d63ad117c6e199b46f9f3f6c651ddba"
+        "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#4407577ae52a8e0b1426675fc484aef8bcb0be37d7d025e1bf12586b8e5056ce"
       ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "4407577ae52a8e0b1426675fc484aef8bcb0be37d7d025e1bf12586b8e5056ce"
-      ]
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#ac73be2c234f2bbc42fbdf7561dee01c7d63ad117c6e199b46f9f3f6c651ddba"
     },
     {
-      "ref": "ac73be2c234f2bbc42fbdf7561dee01c7d63ad117c6e199b46f9f3f6c651ddba"
+      "ref": "@cyclonedx/cyclonedx-eslint-testing-reexport-package@0.0.1#4407577ae52a8e0b1426675fc484aef8bcb0be37d7d025e1bf12586b8e5056ce",
+      "dependsOn": [
+        "@cyclonedx/cyclonedx-eslint-testing-custom-package@0.0.1#ac73be2c234f2bbc42fbdf7561dee01c7d63ad117c6e199b46f9f3f6c651ddba"
+      ]
     }
   ]
 }"
@@ -15809,7 +15809,7 @@ exports[`integration package \`@hookform/resolvers\` with shipped sub-package \`
       "name": "cyclonedx-eslint-testbed-hookform-resolvers-subpath",
       "group": "@cyclonedx",
       "version": "1.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx/cyclonedx-eslint-testbed-hookform-resolvers-subpath@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "package \`@hookform/resolvers\` ships a sub-package \`@hookform/resolvers/zod\`",
       "licenses": [
         {
@@ -15828,7 +15828,7 @@ exports[`integration package \`@hookform/resolvers\` with shipped sub-package \`
       "name": "resolvers",
       "group": "@hookform",
       "version": "5.5.7",
-      "bom-ref": "3a78edde2b556ac4c6b1051cec4b353739cf51d5ce3c2d0eb01cb703759780a0",
+      "bom-ref": "@hookform/resolvers@5.5.7#3a78edde2b556ac4c6b1051cec4b353739cf51d5ce3c2d0eb01cb703759780a0",
       "author": "bluebill1049",
       "description": "React Hook Form validation resolvers: Yup, Joi, Superstruct, Zod, Vest, Class Validator, io-ts, Nope, computed-types, TypeBox, arktype, Typanion, Effect-TS and VineJS",
       "scope": "required",
@@ -15861,9 +15861,27 @@ exports[`integration package \`@hookform/resolvers\` with shipped sub-package \`
     },
     {
       "type": "library",
+      "name": "resolvers/zod",
+      "group": "@hookform",
+      "version": "1.0.0",
+      "bom-ref": "@hookform/resolvers/zod@1.0.0#cc336f843689314dba3c7605dd08a4eb1dc5074ac7c4128e98ab25b2d743ce2d",
+      "description": "React Hook Form validation resolver: zod",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40hookform/resolvers%2Fzod@1.0.0"
+    },
+    {
+      "type": "library",
       "name": "react-hook-form",
       "version": "7.83.0",
-      "bom-ref": "b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264",
+      "bom-ref": "react-hook-form@7.83.0#b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264",
       "author": "Beier",
       "description": "Performant, flexible and extensible forms library for React Hooks",
       "scope": "required",
@@ -15896,9 +15914,43 @@ exports[`integration package \`@hookform/resolvers\` with shipped sub-package \`
     },
     {
       "type": "library",
+      "name": "react",
+      "version": "18.3.1",
+      "bom-ref": "react@18.3.1#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/react@18.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/react",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://reactjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "zod",
       "version": "3.25.76",
-      "bom-ref": "b93d3e17f039e15e2437e274ebcdbb3ed8d67e9364959d77611cfb47a75ab999",
+      "bom-ref": "zod@3.25.76#b93d3e17f039e15e2437e274ebcdbb3ed8d67e9364959d77611cfb47a75ab999",
       "author": "Colin McDonnell",
       "description": "TypeScript-first schema declaration and validation library with static type inference",
       "scope": "required",
@@ -15928,92 +15980,40 @@ exports[`integration package \`@hookform/resolvers\` with shipped sub-package \`
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
-    },
-    {
-      "type": "library",
-      "name": "resolvers/zod",
-      "group": "@hookform",
-      "version": "1.0.0",
-      "bom-ref": "cc336f843689314dba3c7605dd08a4eb1dc5074ac7c4128e98ab25b2d743ce2d",
-      "description": "React Hook Form validation resolver: zod",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40hookform/resolvers%2Fzod@1.0.0"
-    },
-    {
-      "type": "library",
-      "name": "react",
-      "version": "18.3.1",
-      "bom-ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
-      "description": "React is a JavaScript library for building user interfaces.",
-      "scope": "required",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/react@18.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact",
-      "externalReferences": [
-        {
-          "url": "https://github.com/facebook/react/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/facebook/react.git#packages/react",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://reactjs.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "3a78edde2b556ac4c6b1051cec4b353739cf51d5ce3c2d0eb01cb703759780a0",
+      "ref": "@cyclonedx/cyclonedx-eslint-testbed-hookform-resolvers-subpath@1.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264"
+        "@hookform/resolvers/zod@1.0.0#cc336f843689314dba3c7605dd08a4eb1dc5074ac7c4128e98ab25b2d743ce2d",
+        "zod@3.25.76#b93d3e17f039e15e2437e274ebcdbb3ed8d67e9364959d77611cfb47a75ab999"
       ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@hookform/resolvers@5.5.7#3a78edde2b556ac4c6b1051cec4b353739cf51d5ce3c2d0eb01cb703759780a0",
       "dependsOn": [
-        "b93d3e17f039e15e2437e274ebcdbb3ed8d67e9364959d77611cfb47a75ab999",
-        "cc336f843689314dba3c7605dd08a4eb1dc5074ac7c4128e98ab25b2d743ce2d"
+        "react-hook-form@7.83.0#b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264"
       ]
     },
     {
-      "ref": "b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264",
+      "ref": "@hookform/resolvers/zod@1.0.0#cc336f843689314dba3c7605dd08a4eb1dc5074ac7c4128e98ab25b2d743ce2d",
       "dependsOn": [
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+        "@hookform/resolvers@5.5.7#3a78edde2b556ac4c6b1051cec4b353739cf51d5ce3c2d0eb01cb703759780a0",
+        "react-hook-form@7.83.0#b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264"
       ]
     },
     {
-      "ref": "b93d3e17f039e15e2437e274ebcdbb3ed8d67e9364959d77611cfb47a75ab999"
-    },
-    {
-      "ref": "cc336f843689314dba3c7605dd08a4eb1dc5074ac7c4128e98ab25b2d743ce2d",
+      "ref": "react-hook-form@7.83.0#b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264",
       "dependsOn": [
-        "3a78edde2b556ac4c6b1051cec4b353739cf51d5ce3c2d0eb01cb703759780a0",
-        "b280ff1e3f5029fcf885b5b4d6744e19221633c1fe90d12d2ed37daca7d9f264"
+        "react@18.3.1#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
       ]
     },
     {
-      "ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+      "ref": "react@18.3.1#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+    },
+    {
+      "ref": "zod@3.25.76#b93d3e17f039e15e2437e274ebcdbb3ed8d67e9364959d77611cfb47a75ab999"
     }
   ]
 }"


### PR DESCRIPTION


### Description

Reproducible `bom-ref`s might have had almost constant values over multiple builds of different projects.
This is not an issue, since `bom-ref` values are technically allowed to be the same in various SBOMs, but this might have lead to conflicts in downstream use cases.

new: reproducible `bom-refs` are component-based and still are reproducible for unique value parts.  

at the point of adding those hashes, the `bom-ref` are already set to `<package-name>@<version>>`

fixes https://github.com/CycloneDX/cyclonedx-esbuild/issues/185

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-webpack-plugin/blob/main/CONTRIBUTING.md) guidelines
